### PR TITLE
bug fix for FVEG scaling of canopy heat storage

### DIFF
--- a/src/module_sf_noahmplsm.F
+++ b/src/module_sf_noahmplsm.F
@@ -4052,14 +4052,14 @@ ENDIF   ! CROPTYPE == 0
 
         B   = SAV-IRC-SHC-EVC-TR+PAHV                          !additional w/m2
 !        A   = FVEG*(4.0*CIR*TV**3 + CSH + (CEV+CTR)*DESTV) !volumetric heat capacity
-        A   = FVEG*(4.0*CIR*TV**3 + CSH + (CEV+CTR)*DESTV) + HCV/DT  ! total volumetric heat capacity, add canopy heat capacity, more stable
+        A   = FVEG*(4.0*CIR*TV**3 + CSH + (CEV+CTR)*DESTV + HCV/DT)  ! total volumetric heat capacity, add canopy heat capacity, more stable
         DTV = B/A
 
         IRC = IRC + FVEG*4.0*CIR*TV**3*DTV
         SHC = SHC + FVEG*CSH*DTV
         EVC = EVC + FVEG*CEV*DESTV*DTV
         TR  = TR  + FVEG*CTR*DESTV*DTV                               
-        CANHS = DTV * HCV/DT    ! w/m2 canopy heat storage change
+        CANHS = DTV * FVEG*HCV/DT    ! w/m2 canopy heat storage change
 
 ! update vegetation surface temperature
         TV  = TV + DTV


### PR DESCRIPTION
This is a bug fix to solve the issue: https://github.com/NCAR/noahmp/issues/86
Specifically, current canopy heat storage change term is not scaled by FVEG (vegetation fraction), but all the other canopy-related heat flux terms are scaled by FVEG to get the grid-level value before calculating the energy balance. So a FVEG scaling is needed to apply to the canopy heat storage change term.