### PR TITLE
Implementing the Wetland Model from Zhang et al. (2022) WRR

### DIFF
--- a/drivers/hrldas/ConfigVarInTransferMod.F90
+++ b/drivers/hrldas/ConfigVarInTransferMod.F90
@@ -58,6 +58,7 @@ contains
     noahmp%config%nmlist%OptPedotransfer             = NoahmpIO%IOPT_PEDO
     noahmp%config%nmlist%OptRunoffSurface            = NoahmpIO%IOPT_RUNSRF
     noahmp%config%nmlist%OptRunoffSubsurface         = NoahmpIO%IOPT_RUNSUB
+    noahmp%config%nmlist%OptWetlandModel             = NoahmpIO%IOPT_WETLAND ! Add an entry for wetland model, Zhe Zhang
     noahmp%config%nmlist%OptGlacierTreatment         = NoahmpIO%IOPT_GLA
 
     ! config domain variable
@@ -129,12 +130,11 @@ contains
 
     ! treatment for urban point
     if ( (NoahmpIO%IVGTYP(I,J) == NoahmpIO%ISURBAN_TABLE) .or. (NoahmpIO%IVGTYP(I,J) > NoahmpIO%URBTYPE_beg) ) then
-       if ( NoahmpIO%SF_URBAN_PHYSICS == 0 ) then
-           noahmp%config%domain%VegType = NoahmpIO%ISURBAN_TABLE  ! treat as bulk urban point
-           noahmp%config%domain%FlagUrban = .true.
+       noahmp%config%domain%FlagUrban = .true. 
+       if(NoahmpIO%SF_URBAN_PHYSICS == 0 ) then
+           noahmp%config%domain%VegType = NoahmpIO%ISURBAN_TABLE
        else
-           noahmp%config%domain%VegType = NoahmpIO%NATURAL_TABLE  ! set rural vegetation type based on table natural
-                                                                  ! urban is handled by explicit urban scheme outside Noah-MP
+           noahmp%config%domain%VegType = NoahmpIO%NATURAL_TABLE  ! set urban vegetation type based on table natural
            NoahmpIO%GVFMAX(I,J)         = 0.96 * 100.0            ! unit: %
        endif         
     endif

--- a/drivers/hrldas/NoahmpIOVarInitMod.F90
+++ b/drivers/hrldas/NoahmpIOVarInitMod.F90
@@ -154,6 +154,8 @@ contains
     if ( .not. allocated (NoahmpIO%CMXY)      ) allocate ( NoahmpIO%CMXY       (XSTART:XEND,               YSTART:YEND) ) ! bulk momentum drag coefficient
     if ( .not. allocated (NoahmpIO%CHXY)      ) allocate ( NoahmpIO%CHXY       (XSTART:XEND,               YSTART:YEND) ) ! bulk sensible heat exchange coefficient
     if ( .not. allocated (NoahmpIO%FWETXY)    ) allocate ( NoahmpIO%FWETXY     (XSTART:XEND,               YSTART:YEND) ) ! wetted or snowed fraction of the canopy (-)
+    if ( .not. allocated (NoahmpIO%FSATXY)    ) allocate ( NoahmpIO%FSATXY     (XSTART:XEND,               YSTART:YEND) ) ! saturated fraction of the grid (-)
+    if ( .not. allocated (NoahmpIO%WSURFXY)   ) allocate ( NoahmpIO%WSURFXY    (XSTART:XEND,               YSTART:YEND) ) ! wetland water storage [mm]
     if ( .not. allocated (NoahmpIO%SNEQVOXY)  ) allocate ( NoahmpIO%SNEQVOXY   (XSTART:XEND,               YSTART:YEND) ) ! snow mass at last time step(mm h2o)
     if ( .not. allocated (NoahmpIO%ALBOLDXY)  ) allocate ( NoahmpIO%ALBOLDXY   (XSTART:XEND,               YSTART:YEND) ) ! snow albedo at last time step (-)
     if ( .not. allocated (NoahmpIO%QSNOWXY)   ) allocate ( NoahmpIO%QSNOWXY    (XSTART:XEND,               YSTART:YEND) ) ! snowfall on the ground [mm/s]
@@ -324,6 +326,10 @@ contains
     if ( .not. allocated (NoahmpIO%HARVEST)   ) allocate ( NoahmpIO%HARVEST    (XSTART:XEND,  YSTART:YEND) )
     if ( .not. allocated (NoahmpIO%SEASON_GDD)) allocate ( NoahmpIO%SEASON_GDD (XSTART:XEND,  YSTART:YEND) )
     if ( .not. allocated (NoahmpIO%CROPTYPE)  ) allocate ( NoahmpIO%CROPTYPE   (XSTART:XEND,5,YSTART:YEND) )
+    
+    ! Needed for wetland model (OPT_WETLAND=1)
+    if ( .not. allocated (NoahmpIO%FSATMX)  ) allocate ( NoahmpIO%FSATMX   (XSTART:XEND,  YSTART:YEND) )
+    if ( .not. allocated (NoahmpIO%WCAP)    ) allocate ( NoahmpIO%WCAP     (XSTART:XEND,  YSTART:YEND) )
 
     ! Single- and Multi-layer Urban Models
     if ( NoahmpIO%SF_URBAN_PHYSICS > 0 )  then
@@ -519,6 +525,8 @@ contains
     NoahmpIO%CMXY            = undefined_real
     NoahmpIO%CHXY            = undefined_real
     NoahmpIO%FWETXY          = undefined_real
+    NoahmpIO%FSATXY          = undefined_real
+    NoahmpIO%WSURFXY         = undefined_real
     NoahmpIO%SNEQVOXY        = undefined_real
     NoahmpIO%ALBOLDXY        = undefined_real
     NoahmpIO%QSNOWXY         = undefined_real
@@ -678,6 +686,10 @@ contains
     NoahmpIO%HARVEST         = undefined_real
     NoahmpIO%SEASON_GDD      = undefined_real
     NoahmpIO%CROPTYPE        = undefined_real
+
+    ! wetland model
+    NoahmpIO%FSATMX          = undefined_real
+    NoahmpIO%WCAP            = undefined_real
 
     ! tile drainage
     NoahmpIO%QTDRAIN         = 0.0

--- a/drivers/hrldas/NoahmpIOVarType.F90
+++ b/drivers/hrldas/NoahmpIOVarType.F90
@@ -44,6 +44,7 @@ module NoahmpIOVarType
     integer                                                ::  IOPT_BTR            ! soil moisture factor for stomatal resistance (1-> Noah; 2-> CLM; 3-> SSiB)
     integer                                                ::  IOPT_RUNSRF         ! surface runoff and groundwater (1->SIMGM; 2->SIMTOP; 3->Schaake96; 4->BATS)
     integer                                                ::  IOPT_RUNSUB         ! subsurface runoff option
+    integer                                                ::  IOPT_WETLAND        ! wetland model option
     integer                                                ::  IOPT_SFC            ! surface layer drag coeff (CH & CM) (1->M-O; 2->Chen97)
     integer                                                ::  IOPT_FRZ            ! supercooled liquid water (1-> NY06; 2->Koren99)
     integer                                                ::  IOPT_INF            ! frozen soil permeability (1-> NY06; 2->Koren99)
@@ -192,6 +193,8 @@ module NoahmpIOVarType
     real(kind=kind_noahmp), allocatable, dimension(:,:)    ::  CMXY                ! bulk momentum drag coefficient
     real(kind=kind_noahmp), allocatable, dimension(:,:)    ::  CHXY                ! bulk sensible heat exchange coefficient
     real(kind=kind_noahmp), allocatable, dimension(:,:)    ::  FWETXY              ! wetted or snowed fraction of the canopy (-)
+    real(kind=kind_noahmp), allocatable, dimension(:,:)    ::  FSATXY              ! saturated fraction of the grid (-)
+    real(kind=kind_noahmp), allocatable, dimension(:,:)    ::  WSURFXY             ! wetland water storage
     real(kind=kind_noahmp), allocatable, dimension(:,:)    ::  SNEQVOXY            ! snow mass at last time step(mm h2o)
     real(kind=kind_noahmp), allocatable, dimension(:,:)    ::  ALBOLDXY            ! snow albedo at last time step (-)
     real(kind=kind_noahmp), allocatable, dimension(:,:)    ::  QSNOWXY             ! snowfall on the ground [mm/s]
@@ -360,6 +363,8 @@ module NoahmpIOVarType
 !------------------------------------------------------------------------
     real(kind=kind_noahmp), allocatable, dimension(:,:)    ::  TD_FRACTION         ! tile drainage fraction
 
+
+
 !------------------------------------------------------------------------
 ! Needed for crop model (OPT_CROP=1)
 !------------------------------------------------------------------------
@@ -370,6 +375,13 @@ module NoahmpIOVarType
     real(kind=kind_noahmp), allocatable, dimension(:,:)    :: HARVEST              ! harvest day
     real(kind=kind_noahmp), allocatable, dimension(:,:)    :: SEASON_GDD           ! seasonal GDD
     real(kind=kind_noahmp), allocatable, dimension(:,:,:)  :: CROPTYPE             ! crop type
+
+!------------------------------------------------------------------------
+! Needed for wetland model (OPT_WETLAND=1)
+!------------------------------------------------------------------------
+
+    real(kind=kind_noahmp), allocatable, dimension(:,:)    :: FSATMX               ! maximum saturated fraction
+    real(kind=kind_noahmp), allocatable, dimension(:,:)    :: WCAP                 ! maximum wetland capacity
 
 !------------------------------------------------------------------------
 ! Single- and Multi-layer Urban Models
@@ -757,6 +769,7 @@ module NoahmpIOVarType
     real(kind=kind_noahmp)                                 :: O2_TABLE                  ! o2 partial pressure
     real(kind=kind_noahmp)                                 :: TIMEAN_TABLE              ! gridcell mean topgraphic index (global mean)
     real(kind=kind_noahmp)                                 :: FSATMX_TABLE              ! maximum surface saturated fraction (global mean)
+    real(kind=kind_noahmp)                                 :: WCAP_TABLE                ! maximum surface wetland capacity
     real(kind=kind_noahmp)                                 :: Z0SNO_TABLE               ! snow surface roughness length (m) (0.002)
     real(kind=kind_noahmp)                                 :: SSI_TABLE                 ! liquid water holding capacity for snowpack (m3/m3) (0.03)
     real(kind=kind_noahmp)                                 :: SNOW_RET_FAC_TABLE        ! snowpack water release timescale factor (1/s)

--- a/drivers/hrldas/NoahmpInitMainMod.F90
+++ b/drivers/hrldas/NoahmpInitMainMod.F90
@@ -146,6 +146,8 @@ contains
              NoahmpIO%CMXY(I,J)     = 0.0
              NoahmpIO%CHXY(I,J)     = 0.0
              NoahmpIO%FWETXY(I,J)   = 0.0
+             NoahmpIO%FSATXY(I,J)   = 0.0
+             NoahmpIO%WSURFXY(I,J)  = 0.0 
              NoahmpIO%SNEQVOXY(I,J) = 0.0
              NoahmpIO%ALBOLDXY(I,J) = 0.65
              NoahmpIO%QSNOWXY(I,J)  = 0.0
@@ -187,13 +189,8 @@ contains
                 NoahmpIO%LAI(I,J)      = 0.0
                 NoahmpIO%LAI(I,J)      = max(NoahmpIO%LAI(I,J), 0.05)                       ! at least start with 0.05 for arbitrary initialization (v3.7)
                 NoahmpIO%XSAIXY(I,J)   = max(0.1*NoahmpIO%LAI(I,J), 0.05)                   ! MB: arbitrarily initialize SAI using input LAI (v3.7)
-                if ( NoahmpIO%SF_URBAN_PHYSICS == 0 ) then
-                   NoahmpIO%LFMASSXY(I,J) = NoahmpIO%LAI(I,J) * 1000.0 / &
-                                            max(NoahmpIO%SLA_TABLE(NoahmpIO%IVGTYP(I,J)),1.0)  ! use LAI to initialize (v3.7)
-                else
-                   NoahmpIO%LFMASSXY(I,J) = NoahmpIO%LAI(I,J) * 1000.0 / &
-                                            max(NoahmpIO%SLA_TABLE(NoahmpIO%NATURAL_TABLE),1.0)! use LAI to initialize (v3.7)
-                endif
+                NoahmpIO%LFMASSXY(I,J) = NoahmpIO%LAI(I,J) * 1000.0 / &
+                                         max(NoahmpIO%SLA_TABLE(NoahmpIO%IVGTYP(I,J)),1.0)  ! use LAI to initialize (v3.7)
                 NoahmpIO%STMASSXY(I,J) = NoahmpIO%XSAIXY(I,J) * 1000.0 / 3.0                ! use SAI to initialize (v3.7)
                 NoahmpIO%RTMASSXY(I,J) = 500.0                                              ! these are all arbitrary and probably should be
                 NoahmpIO%WOODXY(I,J)   = 500.0                                              ! in the table or read from initialization

--- a/drivers/hrldas/NoahmpReadNamelistMod.F90
+++ b/drivers/hrldas/NoahmpReadNamelistMod.F90
@@ -74,6 +74,7 @@ contains
     integer                 :: btr_option                         = 1
     integer                 :: surface_runoff_option              = 3
     integer                 :: subsurface_runoff_option           = 3
+    integer                 :: wetland_option                     = 0 
     integer                 :: surface_drag_option                = 1
     integer                 :: supercooled_water_option           = 1
     integer                 :: frozen_soil_option                 = 1
@@ -125,7 +126,7 @@ contains
          btr_option, surface_drag_option, supercooled_water_option,        &
          frozen_soil_option, radiative_transfer_option, snow_albedo_option,               &
          snow_thermal_conductivity, surface_runoff_option, subsurface_runoff_option,      &
-         pcp_partition_option, tbot_option, temp_time_scheme_option,                      &
+         wetland_option, pcp_partition_option, tbot_option, temp_time_scheme_option,      &
          glacier_option, surface_resistance_option,                                       &
          irrigation_option, irrigation_method, dvic_infiltration_option,                  &
          tile_drainage_option,soil_data_option, pedotransfer_option, crop_option,         &
@@ -325,6 +326,7 @@ contains
     NoahmpIO%IOPT_BTR                          = btr_option
     NoahmpIO%IOPT_RUNSRF                       = surface_runoff_option
     NoahmpIO%IOPT_RUNSUB                       = subsurface_runoff_option
+    NoahmpIO%IOPT_WETLAND                      = wetland_option
     NoahmpIO%IOPT_SFC                          = surface_drag_option
     NoahmpIO%IOPT_FRZ                          = supercooled_water_option
     NoahmpIO%IOPT_INF                          = frozen_soil_option

--- a/drivers/hrldas/NoahmpReadTableMod.F90
+++ b/drivers/hrldas/NoahmpReadTableMod.F90
@@ -106,14 +106,14 @@ contains
                                                 BETADS, BETAIS, EG, EICE
 
     ! global parameters
-    real(kind=kind_noahmp)                   :: CO2, O2, TIMEAN, FSATMX, Z0SNO, SSI, SNOW_RET_FAC ,SNOW_EMIS, SWEMX, TAU0,   &
+    real(kind=kind_noahmp)                   :: CO2, O2, TIMEAN, FSATMX, WCAP, Z0SNO, SSI, SNOW_RET_FAC ,SNOW_EMIS, SWEMX, TAU0,   &
                                                 GRAIN_GROWTH, EXTRA_GROWTH, DIRT_SOOT, BATS_COSZ, BATS_VIS_NEW,              &
                                                 BATS_NIR_NEW, BATS_VIS_AGE, BATS_NIR_AGE, BATS_VIS_DIR, BATS_NIR_DIR,        &
                                                 RSURF_SNOW, RSURF_EXP, C2_SNOWCOMPACT, C3_SNOWCOMPACT, C4_SNOWCOMPACT,       &
                                                 C5_SNOWCOMPACT, DM_SNOWCOMPACT, ETA0_SNOWCOMPACT, SNLIQMAXFRAC, SWEMAXGLA,   &
                                                 WSLMAX, ROUS, CMIC, SNOWDEN_MAX, CLASS_ALB_REF, CLASS_SNO_AGE, CLASS_ALB_NEW,&
                                                 PSIWLT, Z0SOIL, Z0LAKE
-    namelist / noahmp_global_parameters /       CO2, O2, TIMEAN, FSATMX, Z0SNO, SSI, SNOW_RET_FAC ,SNOW_EMIS, SWEMX, TAU0,   &
+    namelist / noahmp_global_parameters /       CO2, O2, TIMEAN, FSATMX, WCAP, Z0SNO, SSI, SNOW_RET_FAC ,SNOW_EMIS, SWEMX, TAU0,   &
                                                 GRAIN_GROWTH, EXTRA_GROWTH, DIRT_SOOT, BATS_COSZ, BATS_VIS_NEW,              &
                                                 BATS_NIR_NEW, BATS_VIS_AGE, BATS_NIR_AGE, BATS_VIS_DIR, BATS_NIR_DIR,        &
                                                 RSURF_SNOW, RSURF_EXP, C2_SNOWCOMPACT, C3_SNOWCOMPACT, C4_SNOWCOMPACT,       &
@@ -485,6 +485,7 @@ contains
     NoahmpIO%O2_TABLE               = undefined_real
     NoahmpIO%TIMEAN_TABLE           = undefined_real
     NoahmpIO%FSATMX_TABLE           = undefined_real
+    NoahmpIO%WCAP_TABLE             = undefined_real
     NoahmpIO%Z0SNO_TABLE            = undefined_real
     NoahmpIO%SSI_TABLE              = undefined_real
     NoahmpIO%SNOW_RET_FAC_TABLE     = undefined_real
@@ -881,6 +882,7 @@ contains
     NoahmpIO%O2_TABLE               = O2
     NoahmpIO%TIMEAN_TABLE           = TIMEAN
     NoahmpIO%FSATMX_TABLE           = FSATMX
+    NoahmpIO%WCAP_TABLE             = WCAP
     NoahmpIO%Z0SNO_TABLE            = Z0SNO
     NoahmpIO%SSI_TABLE              = SSI
     NoahmpIO%SNOW_RET_FAC_TABLE     = SNOW_RET_FAC

--- a/drivers/hrldas/WaterVarInTransferMod.F90
+++ b/drivers/hrldas/WaterVarInTransferMod.F90
@@ -43,7 +43,8 @@ contains
               SoilType        => noahmp%config%domain%SoilType        ,&
               FlagUrban       => noahmp%config%domain%FlagUrban       ,&
               RunoffSlopeType => noahmp%config%domain%RunoffSlopeType ,&
-              NumSnowLayerNeg => noahmp%config%domain%NumSnowLayerNeg  &
+              NumSnowLayerNeg => noahmp%config%domain%NumSnowLayerNeg ,&
+              OptWetlandModel => noahmp%config%nmlist%OptWetlandModel  &
              )
 ! -------------------------------------------------------------------------
 
@@ -77,6 +78,8 @@ contains
     noahmp%water%state%SoilMoistureEqui  (1:NumSoilLayer) = NoahmpIO%SMOISEQ    (I,1:NumSoilLayer,J)
     noahmp%water%state%RechargeGwDeepWT                   = 0.0
     noahmp%water%state%RechargeGwShallowWT                = 0.0
+    noahmp%water%state%SoilSaturateFrac                   = NoahmpIO%FSATXY     (I,J)
+    noahmp%water%state%WaterStorageWetland                = NoahmpIO%WSURFXY    (I,J)
 #ifdef WRF_HYDRO
     noahmp%water%state%WaterTableHydro                    = NoahmpIO%ZWATBLE2D  (I,J)
     noahmp%water%state%WaterHeadSfc                       = NoahmpIO%sfcheadrt  (I,J)
@@ -111,6 +114,7 @@ contains
     noahmp%water%param%GroundFrzCoeff                     = NoahmpIO%FRZK_TABLE
     noahmp%water%param%GridTopoIndex                      = NoahmpIO%TIMEAN_TABLE
     noahmp%water%param%SoilSfcSatFracMax                  = NoahmpIO%FSATMX_TABLE
+    noahmp%water%param%WetlandCapMax                      = NoahmpIO%WCAP_TABLE
     noahmp%water%param%SpecYieldGw                        = NoahmpIO%ROUS_TABLE
     noahmp%water%param%MicroPoreContent                   = NoahmpIO%CMIC_TABLE
     noahmp%water%param%WaterStorageLakeMax                = NoahmpIO%WSLMAX_TABLE
@@ -157,6 +161,12 @@ contains
        noahmp%water%param%SoilExpCoeffB         (IndexSoilLayer) = NoahmpIO%BEXP_TABLE  (SoilType(IndexSoilLayer))
        noahmp%water%param%SoilMatPotentialSat   (IndexSoilLayer) = NoahmpIO%PSISAT_TABLE(SoilType(IndexSoilLayer))
     enddo
+
+    ! spatial varying wetland parameters from input
+    if ( OptWetlandModel == 2 ) then
+       noahmp%water%param%SoilSfcSatFracMax      = NoahmpIO%FSATMX(I,J)
+       noahmp%water%param%WetlandCapMax          = NoahmpIO%WCAP(I,J)
+    endif 
    
     ! spatial varying soil texture and properties directly from input
     if ( noahmp%config%nmlist%OptSoilProperty == 4 ) then

--- a/drivers/hrldas/WaterVarOutTransferMod.F90
+++ b/drivers/hrldas/WaterVarOutTransferMod.F90
@@ -123,6 +123,8 @@ contains
     NoahmpIO%RECHXY      (I,J) = NoahmpIO%RECHXY(I,J) + (noahmp%water%state%RechargeGwShallowWT*1.0e3)
     NoahmpIO%DEEPRECHXY  (I,J) = NoahmpIO%DEEPRECHXY(I,J) + noahmp%water%state%RechargeGwDeepWT
     NoahmpIO%SMCWTDXY    (I,J) = noahmp%water%state%SoilMoistureToWT
+    NoahmpIO%WSURFXY     (I,J) = noahmp%water%state%WaterStorageWetland
+    NoahmpIO%FSATXY      (I,J) = noahmp%water%state%SoilSaturateFrac
     NoahmpIO%SMOIS       (I,1:NumSoilLayer,J)       = noahmp%water%state%SoilMoisture(1:NumSoilLayer)
     NoahmpIO%SH2O        (I,1:NumSoilLayer,J)       = noahmp%water%state%SoilLiqWater(1:NumSoilLayer)
     NoahmpIO%ACC_ETRANIXY(I,1:NumSoilLayer,J)       = noahmp%water%flux%TranspWatLossSoilAcc(1:NumSoilLayer)

--- a/parameters/NoahmpTable.TBL
+++ b/parameters/NoahmpTable.TBL
@@ -47,7 +47,7 @@
  ISCROP       =  2  ! crop land type in USGS
  EBLFOREST    = 13  ! evergreen broadleaf forest land type in USGS
  NATURAL      =  5  ! natural vegation type in urban pixel in USGS
- URBTYPE_beg  = 50  ! land type number above which are urban (e.g., LCZ)
+ URBTYPE_beg  = 40  ! land type number above which are urban (e.g., LCZ)
  LCZ_1        = 51  ! urban local climate zone (LCZ) type 1: compact highrise
  LCZ_2        = 52  ! urban local climate zone (LCZ) type 2: compact midrise
  LCZ_3        = 53  ! urban local climate zone (LCZ) type 3: compact lowrise
@@ -243,7 +243,7 @@
  ISCROP       = 12  ! crop land type in MODIS
  EBLFOREST    =  2  ! evergreen broadleaf forest land type in MODIS
  NATURAL      = 14  ! natural vegation type in urban pixel in MODIS
- URBTYPE_beg  = 50  ! land type number above which are urban (e.g., LCZ)
+ URBTYPE_beg  = 40  ! land type number above which are urban (e.g., LCZ)
  LCZ_1        = 51  ! urban local climate zone (LCZ) type 1: compact highrise
  LCZ_2        = 52  ! urban local climate zone (LCZ) type 2: compact midrise
  LCZ_3        = 53  ! urban local climate zone (LCZ) type 3: compact lowrise
@@ -428,6 +428,7 @@
  ! runoff parameters used for SIMTOP and SIMGM
  TIMEAN           = 10.5        ! gridcell mean topgraphic index (global mean)
  FSATMX           = 0.38        ! maximum surface saturated fraction (global mean) 
+ WCAP             = 0.10        ! maximum wetland capacity (tunable) 
  ROUS             = 0.20        ! specific yield [-] for Niu et al. 2007 groundwater scheme (OptRunoffSubsurface=1)
  CMIC             = 0.80        ! microprore content (0.0-1.0), 0.0: close to free drainage
  ! parameters for snow processes

--- a/src/BalanceErrorCheckMod.F90
+++ b/src/BalanceErrorCheckMod.F90
@@ -35,6 +35,7 @@ contains
               CanopyIce              => noahmp%water%state%CanopyIce                ,& ! in,  canopy intercepted ice [mm]
               SnowWaterEquiv         => noahmp%water%state%SnowWaterEquiv           ,& ! in,  snow water equivalent [mm]
               SoilMoisture           => noahmp%water%state%SoilMoisture             ,& ! in,  total soil moisture [m3/m3]
+              WaterStorageWetland    => noahmp%water%state%WaterStorageWetland      ,& ! in,  water storage in wetland [mm]
               WaterStorageAquifer    => noahmp%water%state%WaterStorageAquifer      ,& ! in,  water storage in aquifer [mm]
               WaterStorageTotBeg     => noahmp%water%state%WaterStorageTotBeg        & ! out, total water storage [mm] at the beginning
              )
@@ -42,7 +43,7 @@ contains
 
     ! compute total water storage before NoahMP processes
     if ( SurfaceType == 1 ) then  ! soil
-       WaterStorageTotBeg = CanopyLiqWater + CanopyIce + SnowWaterEquiv + WaterStorageAquifer
+       WaterStorageTotBeg = CanopyLiqWater + CanopyIce + SnowWaterEquiv + WaterStorageAquifer + WaterStorageWetland
        do LoopInd = 1, NumSoilLayer
           WaterStorageTotBeg = WaterStorageTotBeg + SoilMoisture(LoopInd) * ThicknessSnowSoilLayer(LoopInd) * 1000.0
        enddo
@@ -87,6 +88,7 @@ contains
               SnowWaterEquiv          => noahmp%water%state%SnowWaterEquiv           ,& ! in,    snow water equivalent [mm]
               SoilMoisture            => noahmp%water%state%SoilMoisture             ,& ! in,    total soil moisture [m3/m3]
               WaterStorageAquifer     => noahmp%water%state%WaterStorageAquifer      ,& ! in,    water storage in aquifer [mm]
+              WaterStorageWetland     => noahmp%water%state%WaterStorageWetland      ,& ! in,  water storage in wetland [mm]
               WaterStorageTotBeg      => noahmp%water%state%WaterStorageTotBeg       ,& ! in,    total water storage [mm] at the beginning
               PrecipTotRefHeight      => noahmp%water%flux%PrecipTotRefHeight        ,& ! in,    total precipitation [mm/s] at reference height
               EvapCanopyNet           => noahmp%water%flux%EvapCanopyNet             ,& ! in,    evaporation of intercepted water [mm/s]
@@ -116,7 +118,7 @@ contains
     ! only water balance check for every soil timestep
     ! Error in water balance should be < 0.1 mm
     if ( SurfaceType == 1 ) then   ! soil
-       WaterStorageTotEnd = CanopyLiqWater + CanopyIce + SnowWaterEquiv + WaterStorageAquifer
+       WaterStorageTotEnd = CanopyLiqWater + CanopyIce + SnowWaterEquiv + WaterStorageAquifer + WaterStorageWetland
        do LoopInd = 1, NumSoilLayer
           WaterStorageTotEnd = WaterStorageTotEnd + SoilMoisture(LoopInd) * ThicknessSnowSoilLayer(LoopInd) * 1000.0
        enddo
@@ -143,11 +145,11 @@ contains
              write(*, &
                   '("  GridIndexI  GridIndexJ  SfcWaterTotChgAcc  PrecipTotRefHeightAcc  IrrigationRateMicro       &
                        IrrigationRateFlood  EvapCanopyNetAcc  EvapGroundNetAcc  TranspirationAcc  RunoffSurface    &
-                       RunoffSubsurface  WaterTableDepth  TileDrain")')
-             write(*,'(i6,i6,f10.3,10f10.5)') GridIndexI, GridIndexJ, SfcWaterTotChgAcc, PrecipTotAcc,             &
+                       RunoffSubsurface  WaterTableDepth  TileDrain WaterStorageWetland ")')
+             write(*,'(i6,i6,f10.3,11f10.5)') GridIndexI, GridIndexJ, SfcWaterTotChgAcc, PrecipTotAcc,             &
                                               IrrigationRateMicro*1000.0, IrrigationRateFlood*1000.0,              &
                                               EvapCanopyNetAcc, EvapGroundNetAcc, TranspirationAcc, RunoffSurface, &
-                                              RunoffSubsurface, WaterTableDepth, TileDrain
+                                              RunoffSubsurface, WaterTableDepth, TileDrain, WaterStorageWetland
              stop "Error: Water budget problem in NoahMP LSM"
           endif
 #endif

--- a/src/ConfigVarInitMod.F90
+++ b/src/ConfigVarInitMod.F90
@@ -37,6 +37,7 @@ contains
     noahmp%config%nmlist%OptSoilSupercoolWater       = undefined_int
     noahmp%config%nmlist%OptRunoffSurface            = undefined_int
     noahmp%config%nmlist%OptRunoffSubsurface         = undefined_int
+    noahmp%config%nmlist%OptWetlandModel             = undefined_int ! Add an entry for wetland model Zhe Zhang
     noahmp%config%nmlist%OptSoilPermeabilityFrozen   = undefined_int
     noahmp%config%nmlist%OptDynVicInfiltration       = undefined_int
     noahmp%config%nmlist%OptTileDrainage             = undefined_int

--- a/src/ConfigVarType.F90
+++ b/src/ConfigVarType.F90
@@ -83,6 +83,10 @@ module ConfigVarType
     integer :: OptRunoffSubsurface         ! options for drainage & subsurface runoff 
                                               ! 1~8: similar to runoff option, separated from original NoahMP runoff option
                                               ! currently tested & recommended the same option# as surface runoff (default)
+    integer :: OptWetlandModel             ! option for wetland model
+                                              ! 0 -> No Wetland model (default)
+                                              ! 1 -> Single-point, (Zhang, et al. 2022 WRR)
+                                              ! 2 -> 2-D regional
     integer :: OptSoilPermeabilityFrozen   ! options for frozen soil permeability
                                               ! 1 -> linear effects, more permeable (default)
                                               ! 2 -> nonlinear effects, less permeable

--- a/src/Makefile
+++ b/src/Makefile
@@ -36,6 +36,8 @@ OBJS = ConstantDefineMod.o \
        RunoffSurfaceTopModelMmfMod.o \
        RunoffSurfaceVicMod.o \
        RunoffSurfaceXinAnJiangMod.o \
+       RunoffSurfaceWetlandMod.o \
+       WaterWetlandMod.o \
        ShallowWaterTableMmfMod.o \
        SnowfallBelowCanopyMod.o \
        SnowLayerCombineMod.o \
@@ -137,20 +139,17 @@ all:	$(OBJS)
 GroundWaterMmfMod.o: GroundWaterMmfMod.F90
 	@echo ""
 	$(RM) GroundWaterMmfMod.f90
-	$(CPP) $(CPPFLAGS) $(*).F90 > $(*).f90
-	$(COMPILERF90) -c -I../../hrldas/MPP -I. -I../../hrldas/Utility_routines \
-        -I../utility -I../drivers/hrldas $(F90FLAGS) $(FREESOURCE) $(NETCDFMOD) $(*).f90
+	$(CPP) $(CPPFLAGS) $(CPPHRLDAS) $(*).F90 > $(*).f90
+	$(COMPILERF90) -o $(@) -c $(F90FLAGS) $(FREESOURCE) -I ../../hrldas/MPP -I. \
+	-I../../hrldas/Utility_routines -I../utility $(NETCDFMOD) $(*).f90
+	$(RM) GroundWaterMmfMod.f90
 	@echo ""
 
 .F90.o:
-	@echo ""
-	$(RM) $(*).f90
-	$(CPP) $(CPPFLAGS) $(*).F90 > $(*).f90
-	$(COMPILERF90) -c -I. -I../utility -I../drivers/hrldas $(F90FLAGS) $(FREESOURCE) $(NETCDFMOD) $(*).f90
-	@echo ""
+	$(COMPILERF90) -c $(F90FLAGS) $(FREESOURCE) -I../utility -I../drivers/hrldas $(NETCDFMOD) $(*).F90
 
 clean:
-	rm -f *.o *.mod *.exe *.f90
+	rm -f *.o *.mod *.exe
 
 #
 # Dependencies:
@@ -197,6 +196,8 @@ RunoffSurfaceTopModelGrdMod.o:        ../utility/Machine.o NoahmpVarType.o Const
 RunoffSurfaceTopModelMmfMod.o:        ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 RunoffSurfaceVicMod.o:                ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 RunoffSurfaceXinAnJiangMod.o:         ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
+RunoffSurfaceWetlandMod.o:            ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
+SurfaceWetlandMod.o:                  ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 ShallowWaterTableMmfMod.o:            ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 SnowfallBelowCanopyMod.o:             ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 SnowLayerCombineMod.o:                ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o \
@@ -225,7 +226,7 @@ SoilWaterMainMod.o:                   ../utility/Machine.o NoahmpVarType.o Const
                                       RunoffSurfaceTopModelGrdMod.o RunoffSurfaceTopModelEquiMod.o \
                                       RunoffSurfaceFreeDrainMod.o RunoffSurfaceBatsMod.o \
                                       RunoffSurfaceTopModelMmfMod.o RunoffSurfaceVicMod.o \
-                                      RunoffSurfaceXinAnJiangMod.o RunoffSurfaceDynamicVicMod.o \
+                                      RunoffSurfaceXinAnJiangMod.o RunoffSurfaceDynamicVicMod.o RunoffSurfaceWetlandMod.o \
                                       RunoffSubSurfaceEquiWaterTableMod.o RunoffSubSurfaceGroundWaterMod.o \
                                       RunoffSubSurfaceDrainageMod.o RunoffSubSurfaceShallowMmfMod.o \
                                       SoilWaterDiffusionRichardsMod.o SoilMoistureSolverMod.o \
@@ -237,7 +238,7 @@ TileDrainageHooghoudtMod.o:           ../utility/Machine.o NoahmpVarType.o Const
 TileDrainageSimpleMod.o:              ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 WaterMainMod.o:                       ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o \
                                       CanopyHydrologyMod.o SnowWaterMainMod.o IrrigationFloodMod.o \
-                                      IrrigationMicroMod.o SoilWaterMainMod.o
+                                      IrrigationMicroMod.o SoilWaterMainMod.o WaterWetlandMod.o 
 WaterTableDepthSearchMod.o:           ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 WaterTableEquilibriumMod.o:           ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 IrrigationTriggerMod.o:               ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
@@ -313,7 +314,7 @@ BiochemCropMainMod.o:                    ../utility/Machine.o NoahmpVarType.o Co
 IrrigationPrepareMod.o:                  ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o IrrigationTriggerMod.o
 BalanceErrorCheckMod.o:                  ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 GeneralInitMod.o:                        ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
-GroundWaterMmfMod.o:                     ../utility/Machine.o NoahmpVarType.o ../drivers/hrldas/NoahmpIOVarType.o
+GroundWaterMmfMod.o:                     ../utility/Machine.o NoahmpVarType.o ../drivers/hrldas/NoahmpIOVarType.o 
 BalanceErrorCheckGlacierMod.o:           ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 EnergyMainGlacierMod.o:                  ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o SnowCoverGlacierMod.o \
                                          GroundRoughnessPropertyGlacierMod.o GroundThermalPropertyGlacierMod.o \

--- a/src/RunoffSurfaceWetlandMod.F90
+++ b/src/RunoffSurfaceWetlandMod.F90
@@ -1,0 +1,57 @@
+module RunoffSurfaceWetlandMod
+
+!!! Calculate surface runoff based on first-layer soil moisture with wetland scheme (Zhang et al., 2020)
+
+  use Machine
+  use NoahmpVarType
+  use ConstantDefineMod
+
+  implicit none
+
+contains
+
+  subroutine RunoffSurfaceWetland(noahmp)
+
+! ------------------------ Code history --------------------------------------------------
+! Originally embeded in SOILWATER subroutine instead of as a separate subroutine
+! Original code: Guo-Yue Niu and Noah-MP team (Niu et al. 2011)
+! Refactered code: C. He, P. Valayamkunnath, & refactor team (He et al. 2023)
+! ----------------------------------------------------------------------------------------
+
+    implicit none
+
+    type(noahmp_type), intent(inout) :: noahmp
+
+! --------------------------------------------------------------------
+    associate(                                                           &
+              SoilSfcInflowMean => noahmp%water%flux%SoilSfcInflowMean  ,& ! in,  mean water input on soil surface [m/s]
+              SoilSfcSatFracMax => noahmp%water%param%SoilSfcSatFracMax ,& ! in,  maximum surface saturated fraction (global mean)
+              SoilImpervFrac    => noahmp%water%state%SoilImpervFrac    ,& ! in,  impervious fraction due to frozen soil
+              SoilLiqWater      => noahmp%water%state%SoilLiqWater      ,& ! in,  soil water content [m3/m3] 
+              SoilMoistureSat   => noahmp%water%param%SoilMoistureSat   ,& ! in,  saturated value of soil moisture [m3/m3]
+              SoilSaturateFrac  => noahmp%water%state%SoilSaturateFrac  ,& ! out, fractional saturated area for soil moisture
+              RunoffSurface     => noahmp%water%flux%RunoffSurface      ,& ! out, surface runoff [m/s]
+              InfilRateSfc      => noahmp%water%flux%InfilRateSfc        & ! out, infiltration rate at surface [m/s]
+             )
+! ----------------------------------------------------------------------
+
+    ! set up key parameter
+    !RunoffDecayFac = 6.0
+    !RunoffDecayFac = SoilExpCoeffB(1) / 3.0 ! calibratable, GY Niu's update 2022
+
+    ! compute saturated area fraction, based on top-layer soil moisture
+    !SoilSaturateFrac = SoilSfcSatFracMax * exp(-0.5 * RunoffDecayFac * (WaterTableDepth-2.0))
+    !SoilSaturateFrac = SoilSfcSatFracMax * exp(-0.5 * RunoffDecayFac * WaterTableDepth) ! GY Niu's update 2022
+    SoilSaturateFrac = SoilSfcSatFracMax * (SoilLiqWater(1)/SoilMoistureSat(1))
+
+    ! compute surface runoff and infiltration  m/s
+    if ( SoilSfcInflowMean > 0.0 ) then
+       RunoffSurface = SoilSfcInflowMean * ((1.0-SoilImpervFrac(1)) * SoilSaturateFrac + SoilImpervFrac(1))
+       InfilRateSfc  = SoilSfcInflowMean - RunoffSurface 
+    endif
+
+    end associate
+
+  end subroutine RunoffSurfaceWetland
+
+end module RunoffSurfaceWetlandMod

--- a/src/SoilWaterMainMod.F90
+++ b/src/SoilWaterMainMod.F90
@@ -14,6 +14,7 @@ module SoilWaterMainMod
   use RunoffSurfaceVicMod,               only : RunoffSurfaceVIC
   use RunoffSurfaceXinAnJiangMod,        only : RunoffSurfaceXinAnJiang
   use RunoffSurfaceDynamicVicMod,        only : RunoffSurfaceDynamicVic
+  use RunoffSurfaceWetlandMod,           only : RunoffSurfaceWetland  ! ZheZhang 2023
   use RunoffSubSurfaceEquiWaterTableMod, only : RunoffSubSurfaceEquiWaterTable
   use RunoffSubSurfaceGroundWaterMod,    only : RunoffSubSurfaceGroundWater
   use RunoffSubSurfaceDrainageMod,       only : RunoffSubSurfaceDrainage
@@ -67,6 +68,7 @@ contains
               FlagUrban              => noahmp%config%domain%FlagUrban              ,& ! in,    logical flag for urban grid
               OptRunoffSurface       => noahmp%config%nmlist%OptRunoffSurface       ,& ! in,    options for surface runoff
               OptRunoffSubsurface    => noahmp%config%nmlist%OptRunoffSubsurface    ,& ! in,    options for subsurface runoff
+              OptWetlandModel        => noahmp%config%nmlist%OptWetlandModel        ,& ! in,    options for wetland model
               OptTileDrainage        => noahmp%config%nmlist%OptTileDrainage        ,& ! in,    options for tile drainage
               SoilIce                => noahmp%water%state%SoilIce                  ,& ! in,    soil ice content [m3/m3]
               TileDrainFrac          => noahmp%water%state%TileDrainFrac            ,& ! in,    tile drainage map (fraction)
@@ -148,6 +150,7 @@ contains
     if ( OptRunoffSurface == 6 ) call RunoffSurfaceVIC(noahmp,SoilTimeStep)
     if ( OptRunoffSurface == 7 ) call RunoffSurfaceXinAnJiang(noahmp,SoilTimeStep)
     if ( OptRunoffSurface == 8 ) call RunoffSurfaceDynamicVic(noahmp,SoilTimeStep,InfilSfcAcc)
+    if ( OptWetlandModel  >  0 ) call RunoffSurfaceWetland(noahmp)
 
     ! determine iteration times  to solve soil water diffusion and moisture
     NumIterSoilWat = 3

--- a/src/WaterMainMod.F90
+++ b/src/WaterMainMod.F90
@@ -11,6 +11,7 @@ module WaterMainMod
   use IrrigationFloodMod,  only : IrrigationFlood
   use IrrigationMicroMod,  only : IrrigationMicro
   use SoilWaterMainMod,    only : SoilWaterMain
+  use WaterWetlandMod,     only : WaterWetland
 
   implicit none
 
@@ -40,6 +41,7 @@ contains
               FlagUrban              => noahmp%config%domain%FlagUrban              ,& ! in,    urban point flag
               FlagSoilProcess        => noahmp%config%domain%FlagSoilProcess        ,& ! in,    flag to calculate soil processes
               NumSoilTimeStep        => noahmp%config%domain%NumSoilTimeStep        ,& ! in,    number of timesteps for soil process calculation
+              OptWetlandModel        => noahmp%config%nmlist%OptWetlandModel        ,& ! in,    options for wetland model
               VaporizeGrd            => noahmp%water%flux%VaporizeGrd               ,& ! in,    ground vaporize rate total (evap+sublim) [mm/s]
               CondenseVapGrd         => noahmp%water%flux%CondenseVapGrd            ,& ! in,    ground vapor condense rate total (dew+frost) [mm/s]
               RainfallGround         => noahmp%water%flux%RainfallGround            ,& ! in,    ground surface rain rate [mm/s]
@@ -202,6 +204,11 @@ contains
        SpecHumidity2mBare = SpecHumiditySfc
     endif
 
+    ! call surface wetland scheme (Zhe Zhang 2023)
+    ! if namelistoption_wetland >0  
+    if ( OptWetlandModel  > 0 ) then
+       call WaterWetland(noahmp,MainTimeStep)
+    endif 
     end associate
 
   end subroutine WaterMain

--- a/src/WaterVarInitMod.F90
+++ b/src/WaterVarInitMod.F90
@@ -258,6 +258,7 @@ contains
     noahmp%water%param%BaseflowCoeff               = undefined_real
     noahmp%water%param%GridTopoIndex               = undefined_real
     noahmp%water%param%SoilSfcSatFracMax           = undefined_real
+    noahmp%water%param%WetlandCapMax               = undefined_real
     noahmp%water%param%SpecYieldGw                 = undefined_real
     noahmp%water%param%MicroPoreContent            = undefined_real
     noahmp%water%param%WaterStorageLakeMax         = undefined_real

--- a/src/WaterVarType.F90
+++ b/src/WaterVarType.F90
@@ -123,6 +123,7 @@ module WaterVarType
     real(kind=kind_noahmp) :: WaterStorageAquifer        ! water storage in aquifer [mm]
     real(kind=kind_noahmp) :: WaterStorageSoilAqf        ! water storage in aquifer + saturated soil [mm]
     real(kind=kind_noahmp) :: WaterStorageLake           ! water storage in lake (can be negative) [mm] 
+    real(kind=kind_noahmp) :: WaterStorageWetland        ! water storage in wetland [mm] ! Zhe Zhang 2023
     real(kind=kind_noahmp) :: WaterHeadSfc               ! surface water head [mm]
     real(kind=kind_noahmp) :: IrrigationFracGrid         ! total irrigation fraction from input for a grid
     real(kind=kind_noahmp) :: PrecipAreaFrac             ! fraction of the gridcell that receives precipitation
@@ -201,6 +202,7 @@ module WaterVarType
     real(kind=kind_noahmp) :: BaseflowCoeff              ! baseflow coefficient [mm/s]
     real(kind=kind_noahmp) :: GridTopoIndex              ! gridcell mean topgraphic index (global mean)
     real(kind=kind_noahmp) :: SoilSfcSatFracMax          ! maximum surface soil saturated fraction (global mean)
+    real(kind=kind_noahmp) :: WetlandCapMax              ! maximum wetland capacity
     real(kind=kind_noahmp) :: SpecYieldGw                ! specific yield [-] for Niu et al. 2007 groundwater scheme
     real(kind=kind_noahmp) :: MicroPoreContent           ! microprore content (0.0-1.0), 0.0: close to free drainage
     real(kind=kind_noahmp) :: WaterStorageLakeMax        ! maximum lake water storage [mm]

--- a/src/WaterWetlandMod.F90
+++ b/src/WaterWetlandMod.F90
@@ -1,0 +1,105 @@
+module WaterWetlandMod
+
+!!! Calculate surface runoff based on first-layer soil moisture with wetland scheme (Zhang et al., 2020)
+
+  use Machine
+  use NoahmpVarType
+  use ConstantDefineMod
+
+  implicit none
+
+contains
+
+  subroutine WaterWetland(noahmp,TimeStep)
+
+! ------------------------ Code history --------------------------------------------------
+! Originally embeded in SOILWATER subroutine instead of as a separate subroutine
+! Original code: Guo-Yue Niu and Noah-MP team (Niu et al. 2011)
+! Refactered code: C. He, P. Valayamkunnath, & refactor team (He et al. 2023)
+! ----------------------------------------------------------------------------------------
+
+    implicit none
+
+    type(noahmp_type), intent(inout)      :: noahmp
+    real(kind=kind_noahmp), intent(in)    :: TimeStep                      ! timestep (may not be the same as model timestep)
+
+! local variables
+    real(kind=kind_noahmp)           :: WCAP    ! surface wetland storage capacity
+    real(kind=kind_noahmp)           :: LATHEA  ! latent heat vap./sublimation
+    real(kind=kind_noahmp)           :: SC      ! slope of saturation vapor pressure curve
+    real(kind=kind_noahmp)           :: QE      ! qevaporation from P-T method, energy flux [W/m2]
+    real(kind=kind_noahmp)           :: GAM     ! gamma psychrometic constant
+    real(kind=kind_noahmp)           :: FWAT    ! evaporation heat from surface [W/m2]
+    real(kind=kind_noahmp)           :: EWAT    ! evaporation water from surface [mm/s]
+! --------------------------------------------------------------------
+    associate(                                                           &
+              TemperatureSfc    => noahmp%energy%state%TemperatureSfc      ,& ! in, surface temperature [K]
+              RadSwAbsSfc       => noahmp%energy%flux%RadSwAbsSfc          ,& ! in,  total absorbed solar radiation [W/m2]
+              RadSwReflSfc      => noahmp%energy%flux%RadSwReflSfc         ,& ! in,  total reflected solar radiation [W/m2]
+              RadLwNetSfc       => noahmp%energy%flux%RadLwNetSfc          ,& ! in,  total net longwave rad [W/m2] (+ to atm)
+              HeatGroundTot     => noahmp%energy%flux%HeatGroundTot        ,& ! in,  total ground heat flux [W/m2] (+ to soil/snow)
+              SoilSaturateFrac  => noahmp%water%state%SoilSaturateFrac      ,& ! in,  fractional saturated area for soil moisture
+              HeatSensibleSfc   => noahmp%energy%flux%HeatSensibleSfc       ,& ! in,  total sensible heat [W/m2] (+ to atm)
+              WetlandCapMax     => noahmp%water%param%WetlandCapMax         ,& ! in,  maximum wetland capacity [mm]
+              RunoffSurface     => noahmp%water%flux%RunoffSurface          ,& ! inout, surface runoff [m/s]
+              WaterStorageWetland => noahmp%water%state%WaterStorageWetland ,& ! inout,  
+              EvapGroundNet       => noahmp%water%flux%EvapGroundNet        ,& ! inout, accumulated net ground evaporation per soil timestep [mm]
+              HeatLatentGrd       => noahmp%energy%flux%HeatLatentGrd       ,& ! inout, ground evaporation heat flux [W/m2] (+ to atm)
+              HeatLatentCanEvap   => noahmp%energy%flux%HeatLatentCanEvap   ,& ! inout, canopy evaporation heat flux [W/m2] (+ to atm)
+              HeatLatentCanTransp => noahmp%energy%flux%HeatLatentCanTransp  & ! inout, canopy transpiration heat flux [W/m2] (+ to atm)
+             )
+! ----------------------------------------------------------------------
+
+! set initial value
+ EWAT = 0.0
+ FWAT = 0.0
+ WCAP = WetlandCapMax * 1000.0
+
+! set psychrometric constant and SC
+ IF (TemperatureSfc .GT. ConstFreezePoint) THEN 
+    LATHEA = ConstLatHeatEvap
+ ELSE
+    LATHEA = ConstLatHeatSublim
+ ENDIF
+
+! determine gamma
+ IF (TemperatureSfc .LT. 273.15+26.85) THEN
+    GAM = 0.00040
+ ELSE 
+    GAM = 0.00041
+ ENDIF 
+
+! calculate slope SC based on surface temperature
+ if (TemperatureSfc .LT. 273.15+6.85) then
+    SC = 0.00022
+ elseif (TemperatureSfc .LT. 273.15+16.85) then
+    SC = 0.00042
+ elseif (TemperatureSfc .LT. 273.15+26.85) then
+    SC = 0.00078 
+ else 
+    SC = 0.00132
+ endif 
+ 
+
+ QE = 1.26*SC*(RadSwAbsSfc-RadLwNetSfc-HeatGroundTot)/(SC+GAM)           ! QE Potential latent heat W/m2 P-T method
+ WaterStorageWetland = WaterStorageWetland + RunoffSurface     
+ IF (WaterStorageWetland .GT. QE*TimeStep/LATHEA*SoilSaturateFrac) THEN  ! if current wetland storage is larger than PET rate 
+    EWAT = max(QE/LATHEA*SoilSaturateFrac,0.0)                           ! EWAT mm/s
+ ELSE                                                                    ! if current wetland storage is less than PET rate
+    EWAT = max(WaterStorageWetland/TimeStep, 0.0)                        ! use all of it
+ ENDIF 
+ WaterStorageWetland = max(WaterStorageWetland-EWAT*TimeStep,0.0)        ! adjust surface wetland storage
+
+ ! adjuest energy and water balance                            
+ FWAT = EWAT * LATHEA                                                    ! convert evaporation to latent heat flux 
+ HeatSensibleSfc  = HeatSensibleSfc  - FWAT                              ! reduce sensible heat flux
+ HeatLatentGrd    = HeatLatentGrd + FWAT                                 ! increase direct evaporation
+ RunoffSurface = max(WaterStorageWetland-WetlandCapMax*1000.0, 0.0)      ! excessive storage becomes runoff
+ EvapGroundNet = EvapGroundNet + EWAT                                    ! increase direct evaporation
+ WaterStorageWetland = min(WetlandCapMax*1000.0,WaterStorageWetland)
+
+    end associate
+
+  end subroutine WaterWetland
+
+end module WaterWetlandMod


### PR DESCRIPTION
Implementing a wetland water storage model from Zhang et al. 2022 WRR (https://doi.org/10.1029/2021WR030573)
The wetland code has been refactored to the newest version of Noah-MP LSM. 
To activate the wetland, a new namelist entry has been added:
wetland_option = 1 : for single point 
wetland_option = 2 : for 2D regional

Initial test with the refactor wetland code at single point is conducted with the Fen site data from SK, Canada, for three years (see attached pdf).

[Test_Wetland_Code_Output.pdf](https://github.com/NCAR/noahmp/files/12433713/Test_Wetland_Code_Output.pdf)
