### PR TITLE
AtmosForcingMod, OptRainSnowPartition == 5 update for warm instances

### DIFF
--- a/src/AtmosForcingMod.F90
+++ b/src/AtmosForcingMod.F90
@@ -165,7 +165,13 @@ contains
           VapPresSat         = 610.8 * exp( (17.27*TemperatureWetBulb) / (237.3+TemperatureWetBulb) )
           TemperatureWetBulb = TemperatureWetBulb - (VapPresSat - PressureVaporRefHeight) / PsychConst   ! Wang et al., 2019 GRL Eq.2
        enddo
-       FrozenPrecipFrac      = 1.0 / (1.0 + 6.99e-5 * exp(2.0*(TemperatureWetBulb+3.97)))                ! Wang et al., 2019 GRL Eq. 1
+
+        ! If structure created by Ronnie Abolafia-Rosenzweig (Feb 1, 2024) to impose FrozenPrecipFrac=0 on high-temp instances to avoid numerical issues
+        if ( TemperatureWetBulb >= (ConstFreezePoint+5)) then
+            FrozenPrecipFrac = 0
+        else
+            FrozenPrecipFrac      = 1.0 / (1.0 + 6.99e-5 * exp(2.0*(TemperatureWetBulb+3.97)))                ! Wang et al., 2019 GRL Eq. 1
+        endif
     endif
 
     ! rain-snow partitioning

--- a/src/AtmosForcingMod.F90
+++ b/src/AtmosForcingMod.F90
@@ -151,7 +151,7 @@ contains
        endif
     endif
 
-    ! wet-bulb scheme (Wang et al., 2019 GRL), C.He, 12/18/2020
+    ! wet-bulb scheme (Wang et al., 2019 GRL), C.He, 12/18/2020, R. Abolafia-Rosnezweig, 02/01/2024
     if ( OptRainSnowPartition == 5 ) then
        TemperatureDegC = min( 50.0, max(-50.0,(TemperatureAirRefHeight-ConstFreezePoint)) )    ! Kelvin to degree Celsius with limit -50 to +50
        if ( TemperatureAirRefHeight > ConstFreezePoint ) then
@@ -166,7 +166,7 @@ contains
           TemperatureWetBulb = TemperatureWetBulb - (VapPresSat - PressureVaporRefHeight) / PsychConst   ! Wang et al., 2019 GRL Eq.2
        enddo
 
-        if ( TemperatureWetBulb >= (ConstFreezePoint+5)) then !added by RAR 02/2024
+        if ( TemperatureWetBulb >= (ConstFreezePoint+5)) then !avoid numerical errors when temperature is high
             FrozenPrecipFrac = 0
         else
             FrozenPrecipFrac      = 1.0 / (1.0 + 6.99e-5 * exp(2.0*(TemperatureWetBulb+3.97)))                ! Wang et al., 2019 GRL Eq. 1

--- a/src/AtmosForcingMod.F90
+++ b/src/AtmosForcingMod.F90
@@ -166,8 +166,7 @@ contains
           TemperatureWetBulb = TemperatureWetBulb - (VapPresSat - PressureVaporRefHeight) / PsychConst   ! Wang et al., 2019 GRL Eq.2
        enddo
 
-        ! If structure created by Ronnie Abolafia-Rosenzweig (Feb 1, 2024) to impose FrozenPrecipFrac=0 on high-temp instances to avoid numerical issues
-        if ( TemperatureWetBulb >= (ConstFreezePoint+5)) then
+        if ( TemperatureWetBulb >= (ConstFreezePoint+5)) then !added by RAR 02/2024
             FrozenPrecipFrac = 0
         else
             FrozenPrecipFrac      = 1.0 / (1.0 + 6.99e-5 * exp(2.0*(TemperatureWetBulb+3.97)))                ! Wang et al., 2019 GRL Eq. 1

--- a/src/AtmosForcingMod.F90
+++ b/src/AtmosForcingMod.F90
@@ -166,7 +166,7 @@ contains
           TemperatureWetBulb = TemperatureWetBulb - (VapPresSat - PressureVaporRefHeight) / PsychConst   ! Wang et al., 2019 GRL Eq.2
        enddo
 
-        if ( TemperatureWetBulb >= (ConstFreezePoint+5)) then !avoid numerical errors when temperature is high
+        if ( TemperatureWetBulb >= 5) then !avoid numerical errors when temperature is high
             FrozenPrecipFrac = 0
         else
             FrozenPrecipFrac      = 1.0 / (1.0 + 6.99e-5 * exp(2.0*(TemperatureWetBulb+3.97)))                ! Wang et al., 2019 GRL Eq. 1

--- a/src/AtmosForcingMod.F90
+++ b/src/AtmosForcingMod.F90
@@ -153,22 +153,22 @@ contains
 
     ! wet-bulb scheme (Wang et al., 2019 GRL), C.He, 12/18/2020, R. Abolafia-Rosnezweig, 02/01/2024
     if ( OptRainSnowPartition == 5 ) then
-       TemperatureDegC = min( 50.0, max(-50.0,(TemperatureAirRefHeight-ConstFreezePoint)) )    ! Kelvin to degree Celsius with limit -50 to +50
-       if ( TemperatureAirRefHeight > ConstFreezePoint ) then
-          LatHeatVap = ConstLatHeatEvap
-       else
-          LatHeatVap = ConstLatHeatSublim
-       endif
-       PsychConst            = ConstHeatCapacAir * PressureAirRefHeight / (0.622 * LatHeatVap)
-       TemperatureWetBulb    = TemperatureDegC - 5.0    ! first guess wetbulb temperature
-       do LoopInd = 1, LoopNum
-          VapPresSat         = 610.8 * exp( (17.27*TemperatureWetBulb) / (237.3+TemperatureWetBulb) )
-          TemperatureWetBulb = TemperatureWetBulb - (VapPresSat - PressureVaporRefHeight) / PsychConst   ! Wang et al., 2019 GRL Eq.2
-       enddo
 
-        if ( TemperatureWetBulb >= 5) then !avoid numerical errors when temperature is high
-            FrozenPrecipFrac = 0
+        if ( TemperatureAirRefHeight >= (ConstFreezePoint+10) ) then !avoid numerical errors when temperature is high
+            FrozenPrecipFrac = 0.0
         else
+            TemperatureDegC = min( 50.0, max(-50.0,(TemperatureAirRefHeight-ConstFreezePoint)) )    ! Kelvin to degree Celsius with limit -50 to +50
+            if ( TemperatureAirRefHeight > ConstFreezePoint ) then
+                LatHeatVap = ConstLatHeatEvap
+            else
+                LatHeatVap = ConstLatHeatSublim
+            endif
+            PsychConst            = ConstHeatCapacAir * PressureAirRefHeight / (0.622 * LatHeatVap)
+            TemperatureWetBulb    = TemperatureDegC - 5.0    ! first guess wetbulb temperature
+            do LoopInd = 1, LoopNum
+                VapPresSat         = 610.8 * exp( (17.27*TemperatureWetBulb) / (237.3+TemperatureWetBulb) )
+                TemperatureWetBulb = TemperatureWetBulb - (VapPresSat - PressureVaporRefHeight) / PsychConst   ! Wang et al., 2019 GRL Eq.2
+            enddo
             FrozenPrecipFrac      = 1.0 / (1.0 + 6.99e-5 * exp(2.0*(TemperatureWetBulb+3.97)))                ! Wang et al., 2019 GRL Eq. 1
         endif
     endif


### PR DESCRIPTION
Update to set FrozenPrecipFrac = 0.0 for instances of TemperatureAirRefHeight>=10C to avoid numerical errors in rain/snowfall partitioning calculation for warm instances when OptRainSnowPartition == 5. 