### PR TITLE
bug fix for LECH SURFACE FUNCTIONS in Chen97

### DIFF
--- a/src/ResistanceAboveCanopyChen97Mod.F90
+++ b/src/ResistanceAboveCanopyChen97Mod.F90
@@ -62,9 +62,9 @@ contains
 ! local statement functions
     ! LECH'S surface functions
     PSLMU(ZZ) = -0.96 * log(1.0 - 4.5 * ZZ)
-    PSLMS(ZZ) = ZZ * RRIC - 2.076 * (1.0 - 1.0/(ZZ + 1.0))
+    PSLMS(ZZ) = ZZ / RFC - 2.076 * (1.0 - 1.0/(ZZ + 1.0))
     PSLHU(ZZ) = -0.96 * log(1.0 - 4.5 * ZZ)
-    PSLHS(ZZ) = ZZ * RFAC - 2.076 * (1.0 - 1.0/(ZZ + 1.0))
+    PSLHS(ZZ) = ZZ * RFAC - 2.076 * (1.0 - exp(-1.2 * ZZ))
     ! PAULSON'S surface functions
     PSPMU(XX) = -2.0*log( (XX+1.0)*0.5 ) - log( (XX*XX+1.0)*0.5 ) + 2.0*atan(XX) - PIHF
     PSPMS(YY) = 5.0 * YY

--- a/src/ResistanceBareGroundChen97Mod.F90
+++ b/src/ResistanceBareGroundChen97Mod.F90
@@ -63,9 +63,10 @@ contains
 ! local statement functions
     ! LECH'S surface functions
     PSLMU(ZZ) = -0.96 * log(1.0 - 4.5 * ZZ)
-    PSLMS(ZZ) = ZZ * RRIC - 2.076 * (1.0 - 1.0/(ZZ + 1.0))
+    PSLMS(ZZ) = ZZ / RFC - 2.076 * (1.0 - 1.0/(ZZ + 1.0))
     PSLHU(ZZ) = -0.96 * log(1.0 - 4.5 * ZZ)
-    PSLHS(ZZ) = ZZ * RFAC - 2.076 * (1.0 - 1.0/(ZZ + 1.0))
+    PSLHS(ZZ) = ZZ * RFAC - 2.076 * (1.0 - exp(-1.2 * ZZ))
+
     ! PAULSON'S surface functions
     PSPMU(XX) = -2.0*log( (XX+1.0)*0.5 ) - log( (XX*XX+1.0)*0.5 ) + 2.0*atan(XX) - PIHF
     PSPMS(YY) = 5.0 * YY


### PR DESCRIPTION
This is a bug fix for the LECH's surface function in Chen et al. 1997 surface resistance module calculations. This bug and fix were identified in WRF PR: https://github.com/wrf-model/WRF/pull/2032
The WRF PR above provides the reason and original reference for the correct equations. Note that the equations in Chen et al. 1997 are correct, but the current code shows the wrong equation. 