### PR TITLE
parallelization for mmf groundwater scheme

### DIFF
--- a/drivers/hrldas/NoahmpGroundwaterInitMod.F90
+++ b/drivers/hrldas/NoahmpGroundwaterInitMod.F90
@@ -19,13 +19,10 @@ contains
 
   use GroundWaterMmfMod, only : LATERALFLOW
   use module_domain,     only : domain
+#ifdef MPP_LAND
+  use module_mpp_land
+#endif
   
-#if (EM_CORE == 1)
-#ifdef DM_PARALLEL
-  use module_dm     ,    only : ntasks_x,ntasks_y,local_communicator,mytask,ntasks
-  use module_comm_dm,    only : halo_em_hydro_noahmp_sub
-#endif
-#endif
 
     implicit none 
     
@@ -37,7 +34,7 @@ contains
     integer                                             :: I,J,K,ITER,itf,jtf,NITER,NCOUNT,NS
     real(kind=kind_noahmp)                              :: BEXP,SMCMAX,PSISAT,SMCWLT,DWSAT,DKSAT
     real(kind=kind_noahmp)                              :: FRLIQ,SMCEQDEEP
-    real(kind=kind_noahmp)                              :: DELTAT,RCOND,TOTWATER
+    real(kind=kind_noahmp)                              :: DELTAT,RCOND,TOTWATER,RCOUNT
     real(kind=kind_noahmp)                              :: AA,BBB,CC,DD,DX,FUNC,DFUNC,DDZ,EXPON,SMC,FLUX
     real(kind=kind_noahmp), dimension(1:NoahmpIO%NSOIL) :: SMCEQ,ZSOIL
     real(kind=kind_noahmp), dimension(NoahmpIO%ims:NoahmpIO%ime, NoahmpIO%jms:NoahmpIO%jme) :: QLAT, QRF
@@ -99,11 +96,7 @@ contains
     NCOUNT = 0
 
     do NITER = 1, 500
-#if (EM_CORE == 1)
-#ifdef DM_PARALLEL
-#     include "HALO_EM_HYDRO_NOAHMP.inc"
-#endif
-#endif
+
       ! Calculate lateral flow
       if ( (NCOUNT > 0) .or. (NITER == 1) ) then
          QLAT = 0.0
@@ -124,13 +117,15 @@ contains
          enddo
 
       endif
+
+#ifdef MPP_LAND
+      rcount=float(ncount)
+      call sum_real1(rcount)
+      ncount=nint(rcount)
+#endif
+
     enddo !NITER
 
-#if (EM_CORE == 1)
-#ifdef DM_PARALLEL
-#     include "HALO_EM_HYDRO_NOAHMP.inc"
-#endif
-#endif
 
     NoahmpIO%EQZWT=NoahmpIO%ZWTXY
 


### PR DESCRIPTION
Adding parallelization capacity for mmf groundwater scheme
Code modifications done by Gonzalo (gonzalo.miguez@usc.es) and Prasanth (prasanth@iisertvm.ac.in),
tested and implemented by Zhe (zhezhang@ucar.edu)

Two codes are changed under noahmp directory:
/src/GroundWaterMmfMod.F90
/drivers/hrldas/NoahmpGroundwaterInitMod.F90

Essentially use mpp_land in Lateralflow subroutine and groundwater init subroutine:
https://github.com/CharlesZheZhang/noahmp/blob/30d661ab921372103dbd73da44a23d373cbb2618/drivers/hrldas/NoahmpGroundwaterInitMod.F90#L22
These lines moved to under subroutine NoahmpGroundwaterInitMain(grid, NoahmpIO)

Also let all distributed tiles communicate when reaching equilibrium within the 500 loops of lateralflow calls:
https://github.com/CharlesZheZhang/noahmp/blob/30d661ab921372103dbd73da44a23d373cbb2618/drivers/hrldas/NoahmpGroundwaterInitMod.F90#L123
