### PR TITLE
Noahmp irrigation init

### DIFF
--- a/drivers/wrf/module_sf_noahmpdrv.F
+++ b/drivers/wrf/module_sf_noahmpdrv.F
@@ -2003,7 +2003,7 @@ SUBROUTINE PEDOTRANSFER_SR2006(nsoil,sand,clay,orgm,parameters)
     call read_mp_crop_parameters()
     call read_tiledrain_parameters()
     call read_mp_optional_parameters()
-    if(iopt_irr  >= 1) call read_mp_irrigation_parameters()
+    call read_mp_irrigation_parameters(iopt_irr)
 
     IF( .NOT. restart ) THEN
 

--- a/src/module_sf_noahmplsm.F
+++ b/src/module_sf_noahmplsm.F
@@ -12188,8 +12188,10 @@ RSURF_SNOW_TABLE     = RSURF_SNOW
 
   end subroutine read_mp_crop_parameters
 
-  subroutine read_mp_irrigation_parameters()
+  subroutine read_mp_irrigation_parameters(iopt_irr)
     implicit none
+
+    INTEGER, INTENT(in)                                  :: iopt_irr
     integer :: ierr
     logical :: file_named 
 
@@ -12216,12 +12218,18 @@ RSURF_SNOW_TABLE     = RSURF_SNOW
     FIRTFAC_TABLE    = -1.0E36    ! flood application rate factor
     IR_RAIN_TABLE    = -1.0E36    ! maximum precipitation to stop irrigation trigger
 
-    inquire( file='MPTABLE.TBL', exist=file_named ) 
-    if ( file_named ) then
-      open(15, file="MPTABLE.TBL", status='old', form='formatted', action='read', iostat=ierr)
-    else
-      open(15, status='old', form='formatted', action='read', iostat=ierr)
-    end if
+    IF (iopt_irr >= 1) THEN
+      inquire( file='MPTABLE.TBL', exist=file_named ) 
+      if ( file_named ) then
+        open(15, file="MPTABLE.TBL", status='old', form='formatted', action='read', iostat=ierr)
+      else
+        open(15, status='old', form='formatted', action='read', iostat=ierr)
+      end if
+    ELSE
+      ! Nothing to read, nothing to do
+      RETURN
+
+    END IF
 
     if (ierr /= 0) then
        write(*,'("WARNING: Cannot find file MPTABLE.TBL")')


### PR DESCRIPTION
This should fix the issue #115 

The code generalize the initialization of the irrigation matrices in order to avoid NaN values when it is not properly initializated.

This error was detected in debug compilation mode and previously posted in the WRF-MPAS forum [WRF-MPAS #52260](https://forum.mmm.ucar.edu/threads/floating-point-exception-phys-module_sf_noahmplsm-f-at-noahmp_sflx-subroutine.15638/#post-52260)