### PR TITLE
Add new snow cover scheme of Abolafia-Rosenzweig et al 2025

### DIFF
--- a/drivers/erf/ConfigVarInTransferMod.F90
+++ b/drivers/erf/ConfigVarInTransferMod.F90
@@ -61,6 +61,7 @@ contains
     noahmp%config%nmlist%OptGlacierTreatment         = NoahmpIO%IOPT_GLA
     noahmp%config%nmlist%OptSnowCompaction           = NoahmpIO%IOPT_COMPACT
     noahmp%config%nmlist%OptWetlandModel             = NoahmpIO%IOPT_WETLAND
+    noahmp%config%nmlist%OptSnowCoverGround          = NoahmpIO%IOPT_SCF
 
     if ( noahmp%config%nmlist%OptSnowAlbedo == 3 ) then ! SNICAR namelist
        noahmp%config%nmlist%OptSnicarSnowShape          = NoahmpIO%SNICAR_SNOWSHAPE_OPT

--- a/drivers/erf/NoahmpIOVarType.F90
+++ b/drivers/erf/NoahmpIOVarType.F90
@@ -69,6 +69,7 @@ module NoahmpIOVarType
     integer                                                ::  IOPT_INFDV          ! infiltration options for dynamic VIC (1->Philip; 2-> Green-Ampt;3->Smith-Parlange)
     integer                                                ::  IOPT_TDRN           ! drainage option (0->off; 1->simple scheme; 2->Hooghoudt's scheme)
     integer                                                ::  IOPT_COMPACT        ! snowpack compaction (1->Anderson1976; 2->Abolafia-Rosenzweig2024)
+    integer                                                ::  IOPT_SCF            ! snow cover fraction (1->NiuYang07; 2->Abolafia-Rosenzweig2025)
     integer                                                ::  IOPT_WETLAND        ! wetland model option (0->off; 1->Zhang2022 fixed parameter; 2->Zhang2022 read in 2D parameter)
     real(kind=kind_noahmp)                                 ::  XICE_THRESHOLD      ! fraction of grid determining seaice
     real(kind=kind_noahmp)                                 ::  JULIAN              ! Julian day
@@ -923,6 +924,10 @@ module NoahmpIOVarType
     real(kind=kind_noahmp)                                 :: SNOWCOMPACT_P2_AR24_TABLE ! lower constrain for SnowCompactBurdenFac for mid pressure bin from AR24
     real(kind=kind_noahmp)                                 :: SNOWCOMPACT_P3_AR24_TABLE ! lower constrain for SnowCompactBurdenFac for low pressure bin from AR24
     real(kind=kind_noahmp)                                 :: SNOWCOMPACT_Up_AR24_TABLE ! upper constraint on SnowCompactBurdenFac from AR24
+    real(kind=kind_noahmp)                                 :: SCFm1_AR25_TABLE          ! m1 parameter for ground SCF from AR2025
+    real(kind=kind_noahmp)                                 :: SCFm2_AR25_TABLE          ! m2 parameter for ground SCF from AR2025
+    real(kind=kind_noahmp)                                 :: SCfac1_AR25_TABLE         ! SCfac1 parameter for ground SCF from AR2025
+    real(kind=kind_noahmp)                                 :: SCfac2_AR25_TABLE         ! SCfac2 parameter for ground SCF from AR2025
     real(kind=kind_noahmp)                                 :: SNLIQMAXFRAC_TABLE        ! maximum liquid water fraction in snow
     real(kind=kind_noahmp)                                 :: SWEMAXGLA_TABLE           ! Maximum SWE allowed at glaciers (mm)
     real(kind=kind_noahmp)                                 :: WSLMAX_TABLE              ! maximum lake water storage (mm)

--- a/drivers/erf/NoahmpReadNamelistMod.F90
+++ b/drivers/erf/NoahmpReadNamelistMod.F90
@@ -82,6 +82,7 @@ contains
     integer                 :: snow_albedo_option                 = 1
     integer                 :: snow_thermal_conductivity          = 1
     integer                 :: snow_compaction_option             = 2 
+    integer                 :: snow_cover_option                  = 2
     integer                 :: pcp_partition_option               = 1
     integer                 :: tbot_option                        = 2
     integer                 :: temp_time_scheme_option            = 1
@@ -152,7 +153,7 @@ contains
          forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN,                 &
          forcing_name_DirFrac, forcing_name_VisFrac,                                      &
          dynamic_veg_option, canopy_stomatal_resistance_option,                           &
-         btr_option, surface_drag_option, supercooled_water_option,                       &
+         btr_option, surface_drag_option, supercooled_water_option, snow_cover_option,    &
          frozen_soil_option, radiative_transfer_option, snow_albedo_option,               &
          snow_thermal_conductivity, surface_runoff_option, subsurface_runoff_option,      &
          pcp_partition_option, tbot_option, temp_time_scheme_option, wetland_option,      &
@@ -383,6 +384,7 @@ contains
     NoahmpIO%IOPT_TDRN                         = tile_drainage_option
     NoahmpIO%IOPT_COMPACT                      = snow_compaction_option
     NoahmpIO%IOPT_WETLAND                      = wetland_option
+    NoahmpIO%IOPT_SCF                          = snow_cover_option
     ! basic model setup variables
     NoahmpIO%indir                             = indir
     NoahmpIO%forcing_timestep                  = forcing_timestep

--- a/drivers/erf/NoahmpReadTableMod.F90
+++ b/drivers/erf/NoahmpReadTableMod.F90
@@ -112,7 +112,8 @@ contains
                                                 RSURF_SNOW, RSURF_EXP, C2_SNOWCOMPACT, C3_SNOWCOMPACT, C4_SNOWCOMPACT,       &
                                                 C5_SNOWCOMPACT, DM_SNOWCOMPACT, ETA0_SNOWCOMPACT, SNLIQMAXFRAC, SWEMAXGLA,   &
                                                 SNOWCOMPACTm_AR24,SNOWCOMPACTb_AR24,SNOWCOMPACT_P1_AR24, SNOWCOMPACT_P2_AR24,&
-                                                SNOWCOMPACT_P3_AR24, SNOWCOMPACT_Up_AR24,                                    &
+                                                SNOWCOMPACT_P3_AR24, SNOWCOMPACT_Up_AR24, SCFm1_AR25, SCFm2_AR25,            &
+                                                SCfac1_AR25, SCfac2_AR25,                                                    &
                                                 WSLMAX, ROUS, CMIC, SNOWDEN_MAX, CLASS_ALB_REF, CLASS_SNO_AGE, CLASS_ALB_NEW,&
                                                 PSIWLT, Z0SOIL, Z0LAKE, WCAP
     namelist / noahmp_global_parameters /       CO2, O2, TIMEAN, FSATMX, Z0SNO, SSI, SNOW_RET_FAC ,SNOW_EMIS, SWEMX, TAU0,   &
@@ -121,7 +122,8 @@ contains
                                                 RSURF_SNOW, RSURF_EXP, C2_SNOWCOMPACT, C3_SNOWCOMPACT, C4_SNOWCOMPACT,       &
                                                 C5_SNOWCOMPACT, DM_SNOWCOMPACT, ETA0_SNOWCOMPACT, SNLIQMAXFRAC, SWEMAXGLA,   &
                                                 SNOWCOMPACTm_AR24,SNOWCOMPACTb_AR24,SNOWCOMPACT_P1_AR24, SNOWCOMPACT_P2_AR24,&
-                                                SNOWCOMPACT_P3_AR24, SNOWCOMPACT_Up_AR24,                                    &
+                                                SNOWCOMPACT_P3_AR24, SNOWCOMPACT_Up_AR24, SCFm1_AR25, SCFm2_AR25,            &
+                                                SCfac1_AR25, SCfac2_AR25,                                                    &
                                                 WSLMAX, ROUS, CMIC, SNOWDEN_MAX, CLASS_ALB_REF, CLASS_SNO_AGE, CLASS_ALB_NEW,&
                                                 PSIWLT, Z0SOIL, Z0LAKE, WCAP
 
@@ -535,6 +537,10 @@ contains
     NoahmpIO%SNOWCOMPACT_P2_AR24_TABLE = undefined_real
     NoahmpIO%SNOWCOMPACT_P3_AR24_TABLE = undefined_real
     NoahmpIO%SNOWCOMPACT_Up_AR24_TABLE = undefined_real
+    NoahmpIO%SCFm1_AR25_TABLE          = undefined_real
+    NoahmpIO%SCFm2_AR25_TABLE          = undefined_real
+    NoahmpIO%SCfac1_AR25_TABLE         = undefined_real
+    NoahmpIO%SCfac2_AR25_TABLE         = undefined_real
     NoahmpIO%SNLIQMAXFRAC_TABLE        = undefined_real
     NoahmpIO%SWEMAXGLA_TABLE           = undefined_real
     NoahmpIO%WSLMAX_TABLE              = undefined_real
@@ -967,6 +973,10 @@ contains
     NoahmpIO%SNOWCOMPACT_P3_AR24_TABLE = SNOWCOMPACT_P3_AR24
     NoahmpIO%SNOWCOMPACT_Up_AR24_TABLE = SNOWCOMPACT_Up_AR24
     NoahmpIO%SNLIQMAXFRAC_TABLE        = SNLIQMAXFRAC
+    NoahmpIO%SCFm1_AR25_TABLE          = SCFm1_AR25
+    NoahmpIO%SCFm2_AR25_TABLE          = SCFm2_AR25
+    NoahmpIO%SCfac1_AR25_TABLE         = SCfac1_AR25
+    NoahmpIO%SCfac2_AR25_TABLE         = SCfac2_AR25
     NoahmpIO%SWEMAXGLA_TABLE           = SWEMAXGLA
     NoahmpIO%WSLMAX_TABLE              = WSLMAX
     NoahmpIO%ROUS_TABLE                = ROUS

--- a/drivers/erf/NoahmpTable.TBL
+++ b/drivers/erf/NoahmpTable.TBL
@@ -470,14 +470,19 @@
  SNOWCOMPACT_P2_AR24 = 0.018       ! lower constraint for SnowCompactBurdenFac for mid pressure bin from AR24
  SNOWCOMPACT_P3_AR24 = 0.019       ! lower constraint for SnowCompactBurdenFac for low pressure bin from AR24
  SNOWCOMPACT_Up_AR24 = 0.0315      ! upper constraint on SnowCompactBurdenFac from AR24
+ ! snow cover parameters for Abolafia-Rosenzweig et al. 2025 (AR25) scheme
+ SCFm1_AR25          = 0.9713      ! SCFm1 parameter for ground SCF scheme from AR2025
+ SCFm2_AR25          = 0.7436      ! SCFm2 parameter for ground SCF scheme from AR2025
+ SCfac1_AR25         = 0.0062      ! SCfac1 parameter for ground SCF scheme from AR2025
+ SCfac2_AR25         = 0.0555      ! SCfac2 parameter for ground SCF scheme from AR2025
  ! other soil and hydrological parameters
- RSURF_EXP        = 5.0         ! exponent in the shape parameter for soil resistance option 1
- WSLMAX           = 5000.0      ! maximum lake water storage (mm)
- PSIWLT           = -150.0      ! metric potential for wilting point (m)
- Z0SOIL           = 0.002       ! Bare-soil roughness length (m) (i.e., under the canopy)
- Z0LAKE           = 0.01        ! Lake surface roughness length (m)
+ RSURF_EXP           = 5.0         ! exponent in the shape parameter for soil resistance option 1
+ WSLMAX              = 5000.0      ! maximum lake water storage (mm)
+ PSIWLT              = -150.0      ! metric potential for wilting point (m)
+ Z0SOIL              = 0.002       ! Bare-soil roughness length (m) (i.e., under the canopy)
+ Z0LAKE              = 0.01        ! Lake surface roughness length (m)
  ! wetland parameter
- WCAP             = 0.10        ! maximum wetland water holding capacity [m] (tunable) from Zhang et al. 2022
+ WCAP                = 0.10        ! maximum wetland water holding capacity [m] (tunable) from Zhang et al. 2022
 /
 
 &noahmp_snicar_parameters

--- a/drivers/erf/WaterVarInTransferMod.F90
+++ b/drivers/erf/WaterVarInTransferMod.F90
@@ -139,6 +139,10 @@ contains
     noahmp%water%param%SnowCompactP1AR24                  = NoahmpIO%SNOWCOMPACT_P1_AR24_TABLE
     noahmp%water%param%SnowCompactP2AR24                  = NoahmpIO%SNOWCOMPACT_P2_AR24_TABLE
     noahmp%water%param%SnowCompactP3AR24                  = NoahmpIO%SNOWCOMPACT_P3_AR24_TABLE
+    noahmp%water%param%SnowCoverM1AR25                    = NoahmpIO%SCFm1_AR25_TABLE
+    noahmp%water%param%SnowCoverM2AR25                    = NoahmpIO%SCFm2_AR25_TABLE
+    noahmp%water%param%SnowCoverFac1AR25                  = NoahmpIO%SCfac1_AR25_TABLE
+    noahmp%water%param%SnowCoverFac2AR25                  = NoahmpIO%SCfac2_AR25_TABLE
     noahmp%water%param%BurdenFacUpAR24                    = NoahmpIO%SNOWCOMPACT_Up_AR24_TABLE
     noahmp%water%param%SnowLiqFracMax                     = NoahmpIO%SNLIQMAXFRAC_TABLE
     noahmp%water%param%SnowLiqHoldCap                     = NoahmpIO%SSI_TABLE

--- a/drivers/hrldas/ConfigVarInTransferMod.F90
+++ b/drivers/hrldas/ConfigVarInTransferMod.F90
@@ -61,6 +61,7 @@ contains
     noahmp%config%nmlist%OptGlacierTreatment         = NoahmpIO%IOPT_GLA
     noahmp%config%nmlist%OptSnowCompaction           = NoahmpIO%IOPT_COMPACT
     noahmp%config%nmlist%OptWetlandModel             = NoahmpIO%IOPT_WETLAND
+    noahmp%config%nmlist%OptSnowCoverGround          = NoahmpIO%IOPT_SCF
 
     if ( noahmp%config%nmlist%OptSnowAlbedo == 3 ) then ! SNICAR namelist
        noahmp%config%nmlist%OptSnicarSnowShape          = NoahmpIO%SNICAR_SNOWSHAPE_OPT

--- a/drivers/hrldas/NoahmpIOVarType.F90
+++ b/drivers/hrldas/NoahmpIOVarType.F90
@@ -64,6 +64,7 @@ module NoahmpIOVarType
     integer                                                ::  IOPT_INFDV          ! infiltration options for dynamic VIC (1->Philip; 2-> Green-Ampt;3->Smith-Parlange)
     integer                                                ::  IOPT_TDRN           ! drainage option (0->off; 1->simple scheme; 2->Hooghoudt's scheme)
     integer                                                ::  IOPT_COMPACT        ! snowpack compaction (1->Anderson1976; 2->Abolafia-Rosenzweig2024)
+    integer                                                ::  IOPT_SCF            ! snow cover fraction (1->NiuYang07; 2->Abolafia-Rosenzweig2025)
     integer                                                ::  IOPT_WETLAND        ! wetland model option (0->off; 1->Zhang2022 fixed parameter; 2->Zhang2022 read in 2D parameter)
     real(kind=kind_noahmp)                                 ::  XICE_THRESHOLD      ! fraction of grid determining seaice
     real(kind=kind_noahmp)                                 ::  JULIAN              ! Julian day
@@ -921,6 +922,10 @@ module NoahmpIOVarType
     real(kind=kind_noahmp)                                 :: SNOWCOMPACT_P2_AR24_TABLE ! lower constrain for SnowCompactBurdenFac for mid pressure bin from AR24
     real(kind=kind_noahmp)                                 :: SNOWCOMPACT_P3_AR24_TABLE ! lower constrain for SnowCompactBurdenFac for low pressure bin from AR24
     real(kind=kind_noahmp)                                 :: SNOWCOMPACT_Up_AR24_TABLE ! upper constraint on SnowCompactBurdenFac from AR24
+    real(kind=kind_noahmp)                                 :: SCFm1_AR25_TABLE          ! m1 parameter for ground SCF from AR2025
+    real(kind=kind_noahmp)                                 :: SCFm2_AR25_TABLE          ! m2 parameter for ground SCF from AR2025
+    real(kind=kind_noahmp)                                 :: SCfac1_AR25_TABLE         ! SCfac1 parameter for ground SCF from AR2025
+    real(kind=kind_noahmp)                                 :: SCfac2_AR25_TABLE         ! SCfac2 parameter for ground SCF from AR2025
     real(kind=kind_noahmp)                                 :: SNLIQMAXFRAC_TABLE        ! maximum liquid water fraction in snow
     real(kind=kind_noahmp)                                 :: SWEMAXGLA_TABLE           ! Maximum SWE allowed at glaciers (mm)
     real(kind=kind_noahmp)                                 :: WSLMAX_TABLE              ! maximum lake water storage (mm)

--- a/drivers/hrldas/NoahmpReadNamelistMod.F90
+++ b/drivers/hrldas/NoahmpReadNamelistMod.F90
@@ -82,6 +82,7 @@ contains
     integer                 :: snow_albedo_option                 = 1
     integer                 :: snow_thermal_conductivity          = 1
     integer                 :: snow_compaction_option             = 2 
+    integer                 :: snow_cover_option                  = 2
     integer                 :: pcp_partition_option               = 1
     integer                 :: tbot_option                        = 2
     integer                 :: temp_time_scheme_option            = 1
@@ -150,7 +151,7 @@ contains
          forcing_name_LW,forcing_name_SW,forcing_name_PR,forcing_name_SN,                 &
          forcing_name_DirFrac, forcing_name_VisFrac,                                      &
          dynamic_veg_option, canopy_stomatal_resistance_option,                           &
-         btr_option, surface_drag_option, supercooled_water_option,                       &
+         btr_option, surface_drag_option, supercooled_water_option, snow_cover_option,    &
          frozen_soil_option, radiative_transfer_option, snow_albedo_option,               &
          snow_thermal_conductivity, surface_runoff_option, subsurface_runoff_option,      &
          pcp_partition_option, tbot_option, temp_time_scheme_option, wetland_option,      &
@@ -378,6 +379,7 @@ contains
     NoahmpIO%IOPT_TDRN                         = tile_drainage_option
     NoahmpIO%IOPT_COMPACT                      = snow_compaction_option
     NoahmpIO%IOPT_WETLAND                      = wetland_option
+    NoahmpIO%IOPT_SCF                          = snow_cover_option
     ! basic model setup variables
     NoahmpIO%indir                             = indir
     NoahmpIO%forcing_timestep                  = forcing_timestep

--- a/drivers/hrldas/NoahmpReadTableMod.F90
+++ b/drivers/hrldas/NoahmpReadTableMod.F90
@@ -112,7 +112,8 @@ contains
                                                 RSURF_SNOW, RSURF_EXP, C2_SNOWCOMPACT, C3_SNOWCOMPACT, C4_SNOWCOMPACT,       &
                                                 C5_SNOWCOMPACT, DM_SNOWCOMPACT, ETA0_SNOWCOMPACT, SNLIQMAXFRAC, SWEMAXGLA,   &
                                                 SNOWCOMPACTm_AR24,SNOWCOMPACTb_AR24,SNOWCOMPACT_P1_AR24, SNOWCOMPACT_P2_AR24,&
-                                                SNOWCOMPACT_P3_AR24, SNOWCOMPACT_Up_AR24,                                    &
+                                                SNOWCOMPACT_P3_AR24, SNOWCOMPACT_Up_AR24, SCFm1_AR25, SCFm2_AR25,            &
+                                                SCfac1_AR25, SCfac2_AR25,                                                    &
                                                 WSLMAX, ROUS, CMIC, SNOWDEN_MAX, CLASS_ALB_REF, CLASS_SNO_AGE, CLASS_ALB_NEW,&
                                                 PSIWLT, Z0SOIL, Z0LAKE, WCAP
     namelist / noahmp_global_parameters /       CO2, O2, TIMEAN, FSATMX, Z0SNO, SSI, SNOW_RET_FAC ,SNOW_EMIS, SWEMX, TAU0,   &
@@ -121,7 +122,8 @@ contains
                                                 RSURF_SNOW, RSURF_EXP, C2_SNOWCOMPACT, C3_SNOWCOMPACT, C4_SNOWCOMPACT,       &
                                                 C5_SNOWCOMPACT, DM_SNOWCOMPACT, ETA0_SNOWCOMPACT, SNLIQMAXFRAC, SWEMAXGLA,   &
                                                 SNOWCOMPACTm_AR24,SNOWCOMPACTb_AR24,SNOWCOMPACT_P1_AR24, SNOWCOMPACT_P2_AR24,&
-                                                SNOWCOMPACT_P3_AR24, SNOWCOMPACT_Up_AR24,                                    &
+                                                SNOWCOMPACT_P3_AR24, SNOWCOMPACT_Up_AR24, SCFm1_AR25, SCFm2_AR25,            &
+                                                SCfac1_AR25, SCfac2_AR25,                                                    &
                                                 WSLMAX, ROUS, CMIC, SNOWDEN_MAX, CLASS_ALB_REF, CLASS_SNO_AGE, CLASS_ALB_NEW,&
                                                 PSIWLT, Z0SOIL, Z0LAKE, WCAP
 
@@ -535,6 +537,10 @@ contains
     NoahmpIO%SNOWCOMPACT_P2_AR24_TABLE = undefined_real
     NoahmpIO%SNOWCOMPACT_P3_AR24_TABLE = undefined_real
     NoahmpIO%SNOWCOMPACT_Up_AR24_TABLE = undefined_real
+    NoahmpIO%SCFm1_AR25_TABLE          = undefined_real
+    NoahmpIO%SCFm2_AR25_TABLE          = undefined_real
+    NoahmpIO%SCfac1_AR25_TABLE         = undefined_real
+    NoahmpIO%SCfac2_AR25_TABLE         = undefined_real
     NoahmpIO%SNLIQMAXFRAC_TABLE        = undefined_real
     NoahmpIO%SWEMAXGLA_TABLE           = undefined_real
     NoahmpIO%WSLMAX_TABLE              = undefined_real
@@ -966,6 +972,10 @@ contains
     NoahmpIO%SNOWCOMPACT_P2_AR24_TABLE = SNOWCOMPACT_P2_AR24
     NoahmpIO%SNOWCOMPACT_P3_AR24_TABLE = SNOWCOMPACT_P3_AR24
     NoahmpIO%SNOWCOMPACT_Up_AR24_TABLE = SNOWCOMPACT_Up_AR24
+    NoahmpIO%SCFm1_AR25_TABLE          = SCFm1_AR25
+    NoahmpIO%SCFm2_AR25_TABLE          = SCFm2_AR25
+    NoahmpIO%SCfac1_AR25_TABLE         = SCfac1_AR25
+    NoahmpIO%SCfac2_AR25_TABLE         = SCfac2_AR25
     NoahmpIO%SNLIQMAXFRAC_TABLE        = SNLIQMAXFRAC
     NoahmpIO%SWEMAXGLA_TABLE           = SWEMAXGLA
     NoahmpIO%WSLMAX_TABLE              = WSLMAX

--- a/drivers/hrldas/WaterVarInTransferMod.F90
+++ b/drivers/hrldas/WaterVarInTransferMod.F90
@@ -139,6 +139,10 @@ contains
     noahmp%water%param%SnowCompactP1AR24                  = NoahmpIO%SNOWCOMPACT_P1_AR24_TABLE
     noahmp%water%param%SnowCompactP2AR24                  = NoahmpIO%SNOWCOMPACT_P2_AR24_TABLE
     noahmp%water%param%SnowCompactP3AR24                  = NoahmpIO%SNOWCOMPACT_P3_AR24_TABLE
+    noahmp%water%param%SnowCoverM1AR25                    = NoahmpIO%SCFm1_AR25_TABLE
+    noahmp%water%param%SnowCoverM2AR25                    = NoahmpIO%SCFm2_AR25_TABLE
+    noahmp%water%param%SnowCoverFac1AR25                  = NoahmpIO%SCfac1_AR25_TABLE
+    noahmp%water%param%SnowCoverFac2AR25                  = NoahmpIO%SCfac2_AR25_TABLE
     noahmp%water%param%BurdenFacUpAR24                    = NoahmpIO%SNOWCOMPACT_Up_AR24_TABLE
     noahmp%water%param%SnowLiqFracMax                     = NoahmpIO%SNLIQMAXFRAC_TABLE
     noahmp%water%param%SnowLiqHoldCap                     = NoahmpIO%SSI_TABLE

--- a/drivers/lis/ConfigVarInTransferMod.F90
+++ b/drivers/lis/ConfigVarInTransferMod.F90
@@ -61,6 +61,7 @@ contains
     noahmp%config%nmlist%OptGlacierTreatment         = NoahmpIO%IOPT_GLA
     noahmp%config%nmlist%OptSnowCompaction           = NoahmpIO%IOPT_COMPACT
     noahmp%config%nmlist%OptWetlandModel             = NoahmpIO%IOPT_WETLAND
+    noahmp%config%nmlist%OptSnowCoverGround          = NoahmpIO%IOPT_SCF
 
     if ( noahmp%config%nmlist%OptSnowAlbedo == 3 ) then ! SNICAR namelist
        noahmp%config%nmlist%OptSnicarSnowShape          = NoahmpIO%SNICAR_SNOWSHAPE_OPT

--- a/drivers/lis/LisNoahmpParamType.F90
+++ b/drivers/lis/LisNoahmpParamType.F90
@@ -132,6 +132,10 @@ module LisNoahmpParamType
     real(kind=kind_noahmp)      :: SNOWCOMPACT_P2_AR24 ! lower constraint for SnowCompactBurdenFac for mid pressure bin from AR24
     real(kind=kind_noahmp)      :: SNOWCOMPACT_P3_AR24 ! lower constraint for SnowCompactBurdenFac for low pressure bin from AR24
     real(kind=kind_noahmp)      :: SNOWCOMPACT_Up_AR24 ! upper constraint on SnowCompactBurdenFac from AR24
+    real(kind=kind_noahmp)      :: SCFm1_AR25          ! m1 parameter for ground SCF from AR2025
+    real(kind=kind_noahmp)      :: SCFm2_AR25          ! m2 parameter for ground SCF from AR2025
+    real(kind=kind_noahmp)      :: SCfac1_AR25         ! SCfac1 parameter for ground SCF from AR2025
+    real(kind=kind_noahmp)      :: SCfac2_AR25         ! SCfac2 parameter for ground SCF from AR2025
     real(kind=kind_noahmp)      :: SNLIQMAXFRAC        ! maximum liquid water fraction in snow
     real(kind=kind_noahmp)      :: SWEMAXGLA           ! Maximum SWE allowed at glaciers (mm)
     real(kind=kind_noahmp)      :: WSLMAX              ! maximum lake water storage (mm)

--- a/drivers/lis/NoahmpIOVarType.F90
+++ b/drivers/lis/NoahmpIOVarType.F90
@@ -58,6 +58,7 @@ module NoahmpIOVarType
     integer                                                ::  IOPT_INFDV          ! infiltration options for dynamic VIC (1->Philip; 2-> Green-Ampt;3->Smith-Parlange)
     integer                                                ::  IOPT_TDRN           ! drainage option (0->off; 1->simple scheme; 2->Hooghoudt's scheme)
     integer                                                ::  IOPT_COMPACT        ! snowpack compaction (1->Anderson1976; 2->Abolafia-Rosenzweig2024)
+    integer                                                ::  IOPT_SCF            ! snow cover fraction (1->NiuYang07; 2->Abolafia-Rosenzweig2025)
     integer                                                ::  IOPT_WETLAND        ! wetland model option (0->off; 1->Zhang2022 scheme fixed parameter; 2->Zhang2022 read in 2D parameter)
     integer                                                ::  sf_urban_physics    ! urban physics option
     
@@ -894,6 +895,10 @@ module NoahmpIOVarType
     real(kind=kind_noahmp)                                 :: SNOWCOMPACT_P2_AR24_TABLE ! lower constraint for SnowCompactBurdenFac for mid pressure bin from AR24
     real(kind=kind_noahmp)                                 :: SNOWCOMPACT_P3_AR24_TABLE ! lower constraint for SnowCompactBurdenFac for low pressure bin from AR24
     real(kind=kind_noahmp)                                 :: SNOWCOMPACT_Up_AR24_TABLE ! upper constraint on SnowCompactBurdenFac from AR24
+    real(kind=kind_noahmp)                                 :: SCFm1_AR25_TABLE          ! m1 parameter for ground SCF from AR2025
+    real(kind=kind_noahmp)                                 :: SCFm2_AR25_TABLE          ! m2 parameter for ground SCF from AR2025
+    real(kind=kind_noahmp)                                 :: SCfac1_AR25_TABLE         ! SCfac1 parameter for ground SCF from AR2025
+    real(kind=kind_noahmp)                                 :: SCfac2_AR25_TABLE         ! SCfac2 parameter for ground SCF from AR2025
     real(kind=kind_noahmp)                                 :: SNLIQMAXFRAC_TABLE        ! maximum liquid water fraction in snow
     real(kind=kind_noahmp)                                 :: SWEMAXGLA_TABLE           ! Maximum SWE allowed at glaciers (mm)
     real(kind=kind_noahmp)                                 :: WSLMAX_TABLE              ! maximum lake water storage (mm)

--- a/drivers/lis/NoahmpReadTableMod.F90
+++ b/drivers/lis/NoahmpReadTableMod.F90
@@ -112,7 +112,8 @@ contains
                                                 RSURF_SNOW, RSURF_EXP, C2_SNOWCOMPACT, C3_SNOWCOMPACT, C4_SNOWCOMPACT,       &
                                                 C5_SNOWCOMPACT, DM_SNOWCOMPACT, ETA0_SNOWCOMPACT, SNLIQMAXFRAC, SWEMAXGLA,   &
                                                 SNOWCOMPACTm_AR24,SNOWCOMPACTb_AR24,SNOWCOMPACT_P1_AR24, SNOWCOMPACT_P2_AR24,&
-                                                SNOWCOMPACT_P3_AR24, SNOWCOMPACT_Up_AR24,                                    &
+                                                SNOWCOMPACT_P3_AR24, SNOWCOMPACT_Up_AR24, SCFm1_AR25, SCFm2_AR25,            &
+                                                SCfac1_AR25, SCfac2_AR25,                                                    &
                                                 WSLMAX, ROUS, CMIC, SNOWDEN_MAX, CLASS_ALB_REF, CLASS_SNO_AGE, CLASS_ALB_NEW,&
                                                 PSIWLT, Z0SOIL, Z0LAKE, WCAP
     namelist / noahmp_global_parameters /       CO2, O2, TIMEAN, FSATMX, Z0SNO, SSI, SNOW_RET_FAC ,SNOW_EMIS, SWEMX, TAU0,   &
@@ -121,7 +122,8 @@ contains
                                                 RSURF_SNOW, RSURF_EXP, C2_SNOWCOMPACT, C3_SNOWCOMPACT, C4_SNOWCOMPACT,       &
                                                 C5_SNOWCOMPACT, DM_SNOWCOMPACT, ETA0_SNOWCOMPACT, SNLIQMAXFRAC, SWEMAXGLA,   &
                                                 SNOWCOMPACTm_AR24,SNOWCOMPACTb_AR24,SNOWCOMPACT_P1_AR24, SNOWCOMPACT_P2_AR24,&
-                                                SNOWCOMPACT_P3_AR24, SNOWCOMPACT_Up_AR24,                                    &
+                                                SNOWCOMPACT_P3_AR24, SNOWCOMPACT_Up_AR24, SCFm1_AR25, SCFm2_AR25,            &
+                                                SCfac1_AR25, SCfac2_AR25,                                                    &
                                                 WSLMAX, ROUS, CMIC, SNOWDEN_MAX, CLASS_ALB_REF, CLASS_SNO_AGE, CLASS_ALB_NEW,&
                                                 PSIWLT, Z0SOIL, Z0LAKE, WCAP
 
@@ -535,6 +537,10 @@ contains
     NoahmpIO%SNOWCOMPACT_P2_AR24_TABLE = undefined_real
     NoahmpIO%SNOWCOMPACT_P3_AR24_TABLE = undefined_real
     NoahmpIO%SNOWCOMPACT_Up_AR24_TABLE = undefined_real
+    NoahmpIO%SCFm1_AR25_TABLE          = undefined_real
+    NoahmpIO%SCFm2_AR25_TABLE          = undefined_real
+    NoahmpIO%SCfac1_AR25_TABLE         = undefined_real
+    NoahmpIO%SCfac2_AR25_TABLE         = undefined_real
     NoahmpIO%SNLIQMAXFRAC_TABLE        = undefined_real
     NoahmpIO%SWEMAXGLA_TABLE           = undefined_real
     NoahmpIO%WSLMAX_TABLE              = undefined_real
@@ -972,6 +978,10 @@ contains
     NoahmpIO%SNOWCOMPACT_P2_AR24_TABLE = SNOWCOMPACT_P2_AR24
     NoahmpIO%SNOWCOMPACT_P3_AR24_TABLE = SNOWCOMPACT_P3_AR24
     NoahmpIO%SNOWCOMPACT_Up_AR24_TABLE = SNOWCOMPACT_Up_AR24
+    NoahmpIO%SCFm1_AR25_TABLE          = SCFm1_AR25
+    NoahmpIO%SCFm2_AR25_TABLE          = SCFm2_AR25
+    NoahmpIO%SCfac1_AR25_TABLE         = SCfac1_AR25
+    NoahmpIO%SCfac2_AR25_TABLE         = SCfac2_AR25
     NoahmpIO%SNLIQMAXFRAC_TABLE        = SNLIQMAXFRAC
     NoahmpIO%SWEMAXGLA_TABLE           = SWEMAXGLA
     NoahmpIO%WSLMAX_TABLE              = WSLMAX

--- a/drivers/lis/WaterVarInTransferMod.F90
+++ b/drivers/lis/WaterVarInTransferMod.F90
@@ -140,10 +140,10 @@ contains
     noahmp%water%param%SnowCompactP2AR24                  = LISparam%SNOWCOMPACT_P2_AR24
     noahmp%water%param%SnowCompactP3AR24                  = LISparam%SNOWCOMPACT_P3_AR24
     noahmp%water%param%BurdenFacUpAR24                    = LISparam%SNOWCOMPACT_Up_AR24
-    noahmp%water%param%SnowCoverM1AR25                    = LISparam%SCFm1_AR25_TABLE
-    noahmp%water%param%SnowCoverM2AR25                    = LISparam%SCFm2_AR25_TABLE
-    noahmp%water%param%SnowCoverFac1AR25                  = LISparam%SCfac1_AR25_TABLE
-    noahmp%water%param%SnowCoverFac2AR25                  = LISparam%SCfac2_AR25_TABLE
+    noahmp%water%param%SnowCoverM1AR25                    = LISparam%SCFm1_AR25
+    noahmp%water%param%SnowCoverM2AR25                    = LISparam%SCFm2_AR25
+    noahmp%water%param%SnowCoverFac1AR25                  = LISparam%SCfac1_AR25
+    noahmp%water%param%SnowCoverFac2AR25                  = LISparam%SCfac2_AR25
     noahmp%water%param%SnowLiqFracMax                     = LISparam%SNLIQMAXFRAC
     noahmp%water%param%SnowLiqHoldCap                     = LISparam%SSI
     noahmp%water%param%SnowLiqReleaseFac                  = LISparam%SNOW_RET_FAC

--- a/drivers/lis/WaterVarInTransferMod.F90
+++ b/drivers/lis/WaterVarInTransferMod.F90
@@ -140,6 +140,10 @@ contains
     noahmp%water%param%SnowCompactP2AR24                  = LISparam%SNOWCOMPACT_P2_AR24
     noahmp%water%param%SnowCompactP3AR24                  = LISparam%SNOWCOMPACT_P3_AR24
     noahmp%water%param%BurdenFacUpAR24                    = LISparam%SNOWCOMPACT_Up_AR24
+    noahmp%water%param%SnowCoverM1AR25                    = LISparam%SCFm1_AR25_TABLE
+    noahmp%water%param%SnowCoverM2AR25                    = LISparam%SCFm2_AR25_TABLE
+    noahmp%water%param%SnowCoverFac1AR25                  = LISparam%SCfac1_AR25_TABLE
+    noahmp%water%param%SnowCoverFac2AR25                  = LISparam%SCfac2_AR25_TABLE
     noahmp%water%param%SnowLiqFracMax                     = LISparam%SNLIQMAXFRAC
     noahmp%water%param%SnowLiqHoldCap                     = LISparam%SSI
     noahmp%water%param%SnowLiqReleaseFac                  = LISparam%SNOW_RET_FAC

--- a/parameters/NoahmpTable.TBL
+++ b/parameters/NoahmpTable.TBL
@@ -470,14 +470,19 @@
  SNOWCOMPACT_P2_AR24 = 0.018       ! lower constraint for SnowCompactBurdenFac for mid pressure bin from AR24
  SNOWCOMPACT_P3_AR24 = 0.019       ! lower constraint for SnowCompactBurdenFac for low pressure bin from AR24
  SNOWCOMPACT_Up_AR24 = 0.0315      ! upper constraint on SnowCompactBurdenFac from AR24
+ ! snow cover parameters for Abolafia-Rosenzweig et al. 2025 (AR25) scheme
+ SCFm1_AR25          = 0.9713      ! SCFm1 parameter for ground SCF scheme from AR2025
+ SCFm2_AR25          = 0.7436      ! SCFm2 parameter for ground SCF scheme from AR2025
+ SCfac1_AR25         = 0.0062      ! SCfac1 parameter for ground SCF scheme from AR2025
+ SCfac2_AR25         = 0.0555      ! SCfac2 parameter for ground SCF scheme from AR2025
  ! other soil and hydrological parameters
- RSURF_EXP        = 5.0         ! exponent in the shape parameter for soil resistance option 1
- WSLMAX           = 5000.0      ! maximum lake water storage (mm)
- PSIWLT           = -150.0      ! metric potential for wilting point (m)
- Z0SOIL           = 0.002       ! Bare-soil roughness length (m) (i.e., under the canopy)
- Z0LAKE           = 0.01        ! Lake surface roughness length (m)
+ RSURF_EXP           = 5.0         ! exponent in the shape parameter for soil resistance option 1
+ WSLMAX              = 5000.0      ! maximum lake water storage (mm)
+ PSIWLT              = -150.0      ! metric potential for wilting point (m)
+ Z0SOIL              = 0.002       ! Bare-soil roughness length (m) (i.e., under the canopy)
+ Z0LAKE              = 0.01        ! Lake surface roughness length (m)
  ! wetland parameter
- WCAP             = 0.10        ! maximum wetland water holding capacity [m] (tunable) from Zhang et al. 2022
+ WCAP                = 0.10        ! maximum wetland water holding capacity [m] (tunable) from Zhang et al. 2022
 /
 
 &noahmp_snicar_parameters

--- a/src/ConfigVarInitMod.F90
+++ b/src/ConfigVarInitMod.F90
@@ -30,6 +30,7 @@ contains
     noahmp%config%nmlist%OptSurfaceDrag              = undefined_int
     noahmp%config%nmlist%OptStomataResistance        = undefined_int
     noahmp%config%nmlist%OptSnowAlbedo               = undefined_int
+    noahmp%config%nmlist%OptSnowCoverGround          = undefined_int
     noahmp%config%nmlist%OptCanopyRadiationTransfer  = undefined_int
     noahmp%config%nmlist%OptSnowSoilTempTime         = undefined_int
     noahmp%config%nmlist%OptSnowThermConduct         = undefined_int

--- a/src/ConfigVarType.F90
+++ b/src/ConfigVarType.F90
@@ -124,6 +124,9 @@ module ConfigVarType
     integer :: OptSnowCompaction           ! options for ground snow compaction
                                               ! 1 -> original scheme from Anderson (1976)
                                               ! 2 -> new scheme from Abolafia-Rosenzweig et al. (2024)
+    integer :: OptSnowCoverGround          ! options for ground snow cover fraction
+                                              ! 1 -> original scheme from Niu and Yang (07) using veg-class based MPTABLE parameters
+                                              ! 2 -> enhanced scheme from Abolafia-Rosenzweig et al. (2025) adding scale-dependency to ground SCF parameters
     integer :: OptWetlandModel             ! option for wetland model
                                               ! 0 -> No Wetland model
                                               ! 1 -> Single-point/uniform parameter (Zhang, et al. 2022 WRR)

--- a/src/EnergyMainMod.F90
+++ b/src/EnergyMainMod.F90
@@ -40,6 +40,7 @@ module EnergyMainMod
   use NoahmpVarType
   use ConstantDefineMod
   use SnowCoverGroundNiu07Mod,        only : SnowCoverGroundNiu07
+  use SnowCoverGroundAR25Mod,         only : SnowCoverGroundAR25
   use GroundRoughnessPropertyMod,     only : GroundRoughnessProperty
   use GroundThermalPropertyMod,       only : GroundThermalProperty
   use SurfaceAlbedoMod,               only : SurfaceAlbedo
@@ -78,6 +79,7 @@ contains
               RadLwDownRefHeight      => noahmp%forcing%RadLwDownRefHeight           ,& ! in,    downward longwave radiation [W/m2] at reference height
               RadSwDownRefHeight      => noahmp%forcing%RadSwDownRefHeight           ,& ! in,    downward shortwave radiation [W/m2] at reference height
               OptSnowSoilTempTime     => noahmp%config%nmlist%OptSnowSoilTempTime    ,& ! in,    options for snow/soil temperature time scheme
+              OptSnowCoverGround      => noahmp%config%nmlist%OptSnowCoverGround     ,& ! in,    options for ground snow cover
               FlagCropland            => noahmp%config%domain%FlagCropland           ,& ! in,    flag to identify croplands
               FlagSoilProcess         => noahmp%config%domain%FlagSoilProcess        ,& ! in,    flag to determine if calculating soil processes
               NumSoilTimeStep         => noahmp%config%domain%NumSoilTimeStep        ,& ! in,    number of time step for calculating soil processes
@@ -193,8 +195,9 @@ contains
     FlagVegSfc    = .false.
     if ( VegAreaIndEff > 0.0 ) FlagVegSfc = .true.
 
-    ! ground snow cover fraction [Niu and Yang, 2007, JGR]
-    call SnowCoverGroundNiu07(noahmp)
+    ! ground snow cover fraction
+    if ( OptSnowCoverGround == 1 ) call SnowCoverGroundNiu07(noahmp)
+    if ( OptSnowCoverGround == 2 ) call SnowCoverGroundAR25(noahmp)
 
     ! ground and surface roughness length and reference height
     call GroundRoughnessProperty(noahmp, FlagVegSfc)

--- a/src/Makefile
+++ b/src/Makefile
@@ -323,6 +323,7 @@ GroundRoughnessPropertyMod.o:            ../utility/Machine.o NoahmpVarType.o Co
 PsychrometricVariableMod.o:              ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 ResistanceGroundEvaporationMod.o:        ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 SnowCoverGroundNiu07Mod.o:               ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
+SnowCoverGroundAR25Mod.o:                ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 SoilWaterTranspirationMod.o:             ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 SurfaceEmissivityMod.o:                  ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o
 AtmosForcingMod.o:                       ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -100,6 +100,7 @@ OBJS = ConstantDefineMod.o \
        SoilWaterSupercoolKoren99Mod.o \
        SoilWaterSupercoolNiu06Mod.o \
        SnowCoverGroundNiu07Mod.o \
+       SnowCoverGroundAR25Mod.o \
        GroundRoughnessPropertyMod.o \
        SurfaceEmissivityMod.o \
        PsychrometricVariableMod.o \
@@ -286,7 +287,7 @@ EnergyMainMod.o:                      ../utility/Machine.o NoahmpVarType.o Const
                                       SurfaceEnergyFluxBareGroundMod.o SoilSnowTemperatureMainMod.o \
                                       SoilSnowWaterPhaseChangeMod.o SnowCoverGroundNiu07Mod.o SurfaceEmissivityMod.o \
                                       GroundRoughnessPropertyMod.o PsychrometricVariableMod.o ResistanceGroundEvaporationMod.o \
-                                      SoilWaterTranspirationMod.o SurfaceAlbedoMod.o SurfaceRadiationMod.o
+                                      SoilWaterTranspirationMod.o SurfaceAlbedoMod.o SurfaceRadiationMod.o SnowCoverGroundAR25Mod.o
 NoahmpMainMod.o:                      ../utility/Machine.o NoahmpVarType.o ConstantDefineMod.o \
                                       IrrigationPrepareMod.o IrrigationSprinklerMod.o CanopyWaterInterceptMod.o \
                                       PrecipitationHeatAdvectMod.o EnergyMainMod.o WaterMainMod.o AtmosForcingMod.o \

--- a/src/SnowCoverGroundAR25Mod.F90
+++ b/src/SnowCoverGroundAR25Mod.F90
@@ -1,0 +1,58 @@
+module SnowCoverGroundAR25Mod
+
+!!! Compute ground snow cover fraction based on Abolafia-Rosenzweig et al. (2025, JAMES) scheme
+
+  use Machine
+  use NoahmpVarType
+  use ConstantDefineMod
+
+  implicit none
+
+contains
+
+  subroutine SnowCoverGroundAR25(noahmp)
+
+! ------------------------ Code history -----------------------------------
+! Refactered code: C. He, P. Valayamkunnath, & refactor team (He et al. 2023)
+! Code updated: R. Abolafia-Rosenzweig and C. He (Abolafia-Rosenzweig et al., 2025)
+! -------------------------------------------------------------------------
+
+    implicit none
+
+    type(noahmp_type), intent(inout) :: noahmp
+
+! local variable
+    real(kind=kind_noahmp)           :: SnowDensBulk   ! bulk density of snow [Kg/m3]
+    real(kind=kind_noahmp)           :: MeltFac        ! melting factor for snow cover frac
+    real(kind=kind_noahmp)           :: SnowMeltFac    ! snowmelt m parameter (scale-dependent)
+    real(kind=kind_noahmp)           :: SnowCoverFac   ! snow cover factor [scfac] (scale-dependent)
+! --------------------------------------------------------------------
+    associate(                                                           &
+              SnowDepth         => noahmp%water%state%SnowDepth         ,& ! in,  snow depth [m]
+              SnowWaterEquiv    => noahmp%water%state%SnowWaterEquiv    ,& ! in,  snow water equivalent [mm]
+              GridSize          => noahmp%config%domain%GridSize        ,& ! in,  noahmp model grid spacing [m]
+              SnowCoverM1AR25   => noahmp%water%param%SnowCoverM1AR25   ,& ! in,  SCFm1 parameter from AR2025
+              SnowCoverM2AR25   => noahmp%water%param%SnowCoverM2AR25   ,& ! in,  SCFm2 parameter from AR2025
+              SnowCoverFac1AR25 => noahmp%water%param%SnowCoverFac1AR25 ,& ! in,  SCfac1 parameter from AR2025
+              SnowCoverFac2AR25 => noahmp%water%param%SnowCoverFac2AR25 ,& ! in,  SCfac2 parameter from AR2025
+              SnowCoverFrac     => noahmp%water%state%SnowCoverFrac      & ! out, snow cover fraction
+             )
+! ----------------------------------------------------------------------
+
+    SnowCoverFrac = 0.0
+    if ( SnowDepth > 0.0 ) then
+         !calculate SCF parameters as a function of grid size:
+         SnowMeltFac  = SnowCoverM1AR25 + tanh(SnowCoverM2AR25 * min((GridSize/1000),36.0));
+         SnowCoverFac = SnowCoverFac1AR25 * sinh(SnowCoverFac2AR25*min((GridSize/1000),36.0)) + SnowCoverFac2AR25;
+        
+         !using scale-dependent parameters, employ the Niu-Yang 07 SCF soluiton
+         SnowDensBulk  = SnowWaterEquiv / SnowDepth
+         MeltFac       = (SnowDensBulk / 100.0)**SnowMeltFac
+         SnowCoverFrac = tanh( SnowDepth /(SnowCoverFac * MeltFac))
+    endif
+
+    end associate
+
+  end subroutine SnowCoverGroundAR25
+
+end module SnowCoverGroundAR25Mod

--- a/src/WaterVarInitMod.F90
+++ b/src/WaterVarInitMod.F90
@@ -314,6 +314,10 @@ contains
     noahmp%water%param%SnowCompactP1AR24           = undefined_real
     noahmp%water%param%SnowCompactP2AR24           = undefined_real
     noahmp%water%param%SnowCompactP3AR24           = undefined_real
+    noahmp%water%param%SnowCoverM1AR25             = undefined_real
+    noahmp%water%param%SnowCoverM2AR25             = undefined_real
+    noahmp%water%param%SnowCoverFac1AR25           = undefined_real
+    noahmp%water%param%SnowCoverFac2AR25           = undefined_real
     noahmp%water%param%BurdenFacUpAR24             = undefined_real
     noahmp%water%param%SnowLiqFracMax              = undefined_real
     noahmp%water%param%SnowLiqHoldCap              = undefined_real

--- a/src/WaterVarType.F90
+++ b/src/WaterVarType.F90
@@ -203,6 +203,10 @@ module WaterVarType
     real(kind=kind_noahmp) :: SnowCompactP2AR24          ! lower constraint for SnowCompactBurdenFac for mid pressure bin from AR24
     real(kind=kind_noahmp) :: SnowCompactP3AR24          ! lower constraint for SnowCompactBurdenFac for low pressure bin from AR24
     real(kind=kind_noahmp) :: BurdenFacUpAR24            ! upper constraint on SnowCompactBurdenFac from AR24
+    real(kind=kind_noahmp) :: SnowCoverM1AR25            ! SCFm1 ground SCF parameter from AR2025
+    real(kind=kind_noahmp) :: SnowCoverM2AR25            ! SCFm2 ground SCF parameter from AR2025
+    real(kind=kind_noahmp) :: SnowCoverFac1AR25          ! SCfac1 ground SCF parameter from AR2025
+    real(kind=kind_noahmp) :: SnowCoverFac2AR25          ! SCfac2 ground SCF parameter from AR2025
     real(kind=kind_noahmp) :: SnowLiqFracMax             ! maximum liquid water fraction in snow
     real(kind=kind_noahmp) :: SnowLiqHoldCap             ! liquid water holding capacity for snowpack [m3/m3]
     real(kind=kind_noahmp) :: SnowLiqReleaseFac          ! snowpack water release timescale factor [1/s]


### PR DESCRIPTION
This PR is to add a new scale-aware ground snow cover fraction scheme based on Abolafia-Rosenzweig et al 2025, which aims to reduce the long-standing snow cover overestimates over mountains in Noah-MP.

Reference:  Abolafia-Rosenzweig, R., C. He, T.-S. Lin, and M. Barlage (2025): Improved cross-scale snow cover simulations by developing a scale-aware parameterization in the Noah-MP land surface model, Journal of Advances in Modeling Earth Systems.

Original code developer: Ronnie Abolafia-Rosenzweig (NCAR)
Refined code in this PR: Cenlin He (NCAR)

Test for CONUS simulations driven by NLDAS-2 with this scheme on Derecho are successful.
