### PR TITLE
Bug fix to avoid zero or negative gridsize used in Noah-MP

### DIFF
--- a/drivers/erf/ConfigVarInTransferMod.F90
+++ b/drivers/erf/ConfigVarInTransferMod.F90
@@ -91,7 +91,7 @@ contains
     noahmp%config%domain%GridIndexJ                  = NoahmpIO%J
     noahmp%config%domain%MainTimeStep                = NoahmpIO%DTBL
     noahmp%config%domain%SoilTimeStep                = NoahmpIO%DTBL * NoahmpIO%soil_update_steps
-    noahmp%config%domain%GridSize                    = sqrt(NoahmpIO%DX * NoahmpIO%DY)
+    noahmp%config%domain%GridSize                    = sqrt(max(10.0,NoahmpIO%DX) * max(10.0,NoahmpIO%DY))
     noahmp%config%domain%LandUseDataName             = NoahmpIO%LLANDUSE
     noahmp%config%domain%VegType                     = NoahmpIO%IVGTYP(I,J)
     noahmp%config%domain%CropType                    = NoahmpIO%CROPCAT(I,J)

--- a/drivers/erf/NoahmpInitMainMod.F90
+++ b/drivers/erf/NoahmpInitMainMod.F90
@@ -161,7 +161,8 @@ contains
              else
                 NoahmpIO%WAXY(I,J)   = 0.0
                 NoahmpIO%WTXY(I,J)   = 0.0
-                NoahmpIO%AREAXY(I,J) = (NoahmpIO%DX*NoahmpIO%DY) / (NoahmpIO%MSFTX(I,J)*NoahmpIO%MSFTY(I,J))
+                NoahmpIO%AREAXY(I,J) = (max(10.0,NoahmpIO%DX) * max(10.0,NoahmpIO%DY)) / &
+                                       (NoahmpIO%MSFTX(I,J) * NoahmpIO%MSFTY(I,J))
              endif
 
              urbanpt_flag = .false.

--- a/drivers/hrldas/ConfigVarInTransferMod.F90
+++ b/drivers/hrldas/ConfigVarInTransferMod.F90
@@ -91,7 +91,7 @@ contains
     noahmp%config%domain%GridIndexJ                  = NoahmpIO%J
     noahmp%config%domain%MainTimeStep                = NoahmpIO%DTBL
     noahmp%config%domain%SoilTimeStep                = NoahmpIO%DTBL * NoahmpIO%soil_update_steps
-    noahmp%config%domain%GridSize                    = sqrt(NoahmpIO%DX * NoahmpIO%DY)
+    noahmp%config%domain%GridSize                    = sqrt(max(10.0,NoahmpIO%DX) * max(10.0,NoahmpIO%DY))
     noahmp%config%domain%LandUseDataName             = NoahmpIO%LLANDUSE
     noahmp%config%domain%VegType                     = NoahmpIO%IVGTYP(I,J)
     noahmp%config%domain%CropType                    = NoahmpIO%CROPCAT(I,J)

--- a/drivers/hrldas/NoahmpInitMainMod.F90
+++ b/drivers/hrldas/NoahmpInitMainMod.F90
@@ -161,7 +161,8 @@ contains
              else
                 NoahmpIO%WAXY(I,J)   = 0.0
                 NoahmpIO%WTXY(I,J)   = 0.0
-                NoahmpIO%AREAXY(I,J) = (NoahmpIO%DX*NoahmpIO%DY) / (NoahmpIO%MSFTX(I,J)*NoahmpIO%MSFTY(I,J))
+                NoahmpIO%AREAXY(I,J) = (max(10.0,NoahmpIO%DX) * max(10.0,NoahmpIO%DY)) / &
+                                       (NoahmpIO%MSFTX(I,J) * NoahmpIO%MSFTY(I,J))
              endif
 
              urbanpt_flag = .false.

--- a/drivers/lis/ConfigVarInTransferMod.F90
+++ b/drivers/lis/ConfigVarInTransferMod.F90
@@ -91,7 +91,7 @@ contains
     noahmp%config%domain%GridIndexJ                  = NoahmpIO%J
     noahmp%config%domain%MainTimeStep                = NoahmpIO%DTBL
     noahmp%config%domain%SoilTimeStep                = NoahmpIO%DTBL * NoahmpIO%soil_update_steps
-    noahmp%config%domain%GridSize                    = sqrt(NoahmpIO%DX * NoahmpIO%DY)
+    noahmp%config%domain%GridSize                    = sqrt(max(10.0,NoahmpIO%DX) * max(10.0,NoahmpIO%DY))
     noahmp%config%domain%LandUseDataName             = NoahmpIO%LLANDUSE
     noahmp%config%domain%VegType                     = NoahmpIO%IVGTYP(I,J)
     noahmp%config%domain%CropType                    = NoahmpIO%CROPCAT(I,J)

--- a/drivers/lis/NoahmpInitMainMod.F90
+++ b/drivers/lis/NoahmpInitMainMod.F90
@@ -161,7 +161,8 @@ contains
              else
                 NoahmpIO%WAXY(I,J)   = 0.0
                 NoahmpIO%WTXY(I,J)   = 0.0
-                NoahmpIO%AREAXY(I,J) = (NoahmpIO%DX*NoahmpIO%DY) / (NoahmpIO%MSFTX(I,J)*NoahmpIO%MSFTY(I,J))
+                NoahmpIO%AREAXY(I,J) = (max(10.0,NoahmpIO%DX) * max(10.0,NoahmpIO%DY)) / &
+                                       (NoahmpIO%MSFTX(I,J) * NoahmpIO%MSFTY(I,J))
              endif
 
              urbanpt_flag = .false.

--- a/src/SnowCoverGroundAR25Mod.F90
+++ b/src/SnowCoverGroundAR25Mod.F90
@@ -41,11 +41,14 @@ contains
 
     SnowCoverFrac = 0.0
     if ( SnowDepth > 0.0 ) then
-         !calculate SCF parameters as a function of grid size:
-         SnowMeltFac  = SnowCoverM1AR25 + tanh(SnowCoverM2AR25 * min((GridSize/1000),36.0));
-         SnowCoverFac = SnowCoverFac1AR25 * sinh(SnowCoverFac2AR25*min((GridSize/1000),36.0)) + SnowCoverFac2AR25;
+         ! limit gridsize to 500.0 m due to parameterization limitation
+         GridSize = max(500.0, GridSize)
+
+         ! calculate SCF parameters as a function of grid size:
+         SnowMeltFac  = SnowCoverM1AR25 + tanh(SnowCoverM2AR25 * min((GridSize/1000),36.0))
+         SnowCoverFac = SnowCoverFac1AR25 * sinh(SnowCoverFac2AR25*min((GridSize/1000),36.0)) + SnowCoverFac2AR25
         
-         !using scale-dependent parameters, employ the Niu-Yang 07 SCF soluiton
+         ! using scale-dependent parameters, employ the Niu-Yang 07 SCF soluiton
          SnowDensBulk  = SnowWaterEquiv / SnowDepth
          MeltFac       = (SnowDensBulk / 100.0)**SnowMeltFac
          SnowCoverFrac = tanh( SnowDepth /(SnowCoverFac * MeltFac))


### PR DESCRIPTION
This PR is to fix the bug to avoid unrealistic (zero or negative) grid size "DX" and "DY" input values.
Also adds a minimum gridsize limit (500m) for AR25 snow cover parameterization due to the parameterization limitation.
For area variable, put a minimum limit of 10m for DX and DY. This is an arbitrary limit which can be changed in the future.