### PR TITLE
Correct reference height diagnosis for consistency with displacement height

### DIFF
--- a/src/GroundRoughnessPropertyMod.F90
+++ b/src/GroundRoughnessPropertyMod.F90
@@ -76,7 +76,7 @@ contains
     endif
 
     ! reference height above ground
-    RefHeightAboveGrd    = max(ZeroPlaneDispSfc, HeightCanopyTop) + RefHeightAboveSfc
+    RefHeightAboveGrd    = ZeroPlaneDispSfc + RefHeightAboveSfc
     if ( ZeroPlaneDispGrd >= RefHeightAboveGrd ) RefHeightAboveGrd = ZeroPlaneDispGrd + RefHeightAboveSfc
 
     end associate


### PR DESCRIPTION
This PR corrects the diagnosis of the reference height above ground (_RefHeightAboveGrd_) to consider displacement height (_ZeroPlaneDispSfc_) in order to ensureing consistency between forcing reference height (_RefHeightAboveSfc_) and the reference height from effective soild surface (RefHeightAboveGrd - ZeroPlaneDispSfc) in the MOST modules.

The change is a one-line correction.

See detailed discussion in :
Issue #159