### PR TITLE
bug fix for canopy interception and canopy evaporation

### DIFF
--- a/src/SurfaceEnergyFluxVegetatedMod.F90
+++ b/src/SurfaceEnergyFluxVegetatedMod.F90
@@ -278,9 +278,11 @@ contains
         
        if( HeatLatentPotCanEvap > 0.0 .and. CanopyWetFrac > 0.0 ) then
           if ( TemperatureCanopy > ConstFreezePoint ) then
-             ExchCoeffLhEvap = min( CanopyWetFrac, CanopyLiqWater*LatHeatVapCanopy/MainTimeStep/evpot ) * VegAreaIndTmp / ResistanceLeafBoundary
+             ExchCoeffLhEvap = min( CanopyWetFrac, CanopyLiqWater*LatHeatVapCanopy/MainTimeStep/HeatLatentPotCanEvap ) * & 
+                               VegAreaIndTmp / ResistanceLeafBoundary
           else 
-             ExchCoeffLhEvap = min( CanopyWetFrac, CanopyIce*LatHeatVapCanopy/MainTimeStep/evpot ) * VegAreaIndTmp / ResistanceLeafBoundary
+             ExchCoeffLhEvap = min( CanopyWetFrac, CanopyIce*LatHeatVapCanopy/MainTimeStep/HeatLatentPotCanEvap ) * &
+                               VegAreaIndTmp / ResistanceLeafBoundary
           endif
        else
           ExchCoeffLhEvap   = CanopyWetFrac * VegAreaIndTmp / ResistanceLeafBoundary

--- a/src/SurfaceEnergyFluxVegetatedMod.F90
+++ b/src/SurfaceEnergyFluxVegetatedMod.F90
@@ -69,6 +69,7 @@ contains
     real(kind=kind_noahmp)                :: TempTmp                 ! temporary temperature
     real(kind=kind_noahmp)                :: TempUnitConv            ! Kelvin to degree Celsius with limit -50 to +50
     real(kind=kind_noahmp)                :: HeatCapacCan            ! canopy heat capacity [J/m2/K]
+    real(kind=kind_noahmp)                :: HeatLatentPotCanEvap    ! potential evaporation from wet foliage per unit wetted area [W/m2] (+ to atm)
 ! local statement function
     TempUnitConv(TempTmp) = min(50.0, max(-50.0, (TempTmp - ConstFreezePoint)))
 
@@ -273,13 +274,14 @@ contains
        ExchCoeffLhAbvCan = 1.0 / ResistanceLhAbvCan
        ExchCoeffLhEvap   = CanopyWetFrac * VegAreaIndTmp / ResistanceLeafBoundary
 
-       evpot= fveg*rhoair*cpair*vaie/rb * (estv-eah) / gammav
+       HeatLatentPotCanEvap = VegFrac * DensityAirRefHeight * ConstHeatCapacAir * VegAreaIndTmp / ResistanceLeafBoundary * &
+                              (VapPresSatCanopy - PressureVaporCanAir) / PsychConstCanopy
         
-       if( evpot > 0.0 .and. CanopyWetFrac > 0.0 ) then
+       if( HeatLatentPotCanEvap > 0.0 .and. CanopyWetFrac > 0.0 ) then
           if ( TemperatureCanopy > ConstFreezePoint ) then
-             ExchCoeffLhEvap = min( CanopyWetFrac, canliq*latheav/dt/evpot ) * vaie/rb
-          else
-             ExchCoeffLhEvap = min( CanopyWetFrac, canice*latheav/dt/evpot ) * vaie/rb
+             ExchCoeffLhEvap = min( CanopyWetFrac, CanopyLiqWater*LatHeatVapCanopy/MainTimeStep/evpot ) * VegAreaIndTmp / ResistanceLeafBoundary
+          else 
+             ExchCoeffLhEvap = min( CanopyWetFrac, CanopyIce*LatHeatVapCanopy/MainTimeStep/evpot ) * VegAreaIndTmp / ResistanceLeafBoundary
           endif
        else
           ExchCoeffLhEvap   = CanopyWetFrac * VegAreaIndTmp / ResistanceLeafBoundary

--- a/src/SurfaceEnergyFluxVegetatedMod.F90
+++ b/src/SurfaceEnergyFluxVegetatedMod.F90
@@ -272,6 +272,19 @@ contains
        ! latent heat conductance and coeff above veg.
        ExchCoeffLhAbvCan = 1.0 / ResistanceLhAbvCan
        ExchCoeffLhEvap   = CanopyWetFrac * VegAreaIndTmp / ResistanceLeafBoundary
+
+       evpot= fveg*rhoair*cpair*vaie/rb * (estv-eah) / gammav
+        
+       if( evpot > 0.0 .and. CanopyWetFrac > 0.0 ) then
+          if ( TemperatureCanopy > ConstFreezePoint ) then
+             ExchCoeffLhEvap = min( CanopyWetFrac, canliq*latheav/dt/evpot ) * vaie/rb
+          else
+             ExchCoeffLhEvap = min( CanopyWetFrac, canice*latheav/dt/evpot ) * vaie/rb
+          endif
+       else
+          ExchCoeffLhEvap   = CanopyWetFrac * VegAreaIndTmp / ResistanceLeafBoundary
+       endif
+
        ExchCoeffLhTransp = (1.0 - CanopyWetFrac) * (LeafAreaIndSunEff/(ResistanceLeafBoundary+ResistanceStomataSunlit) + &
                                                     LeafAreaIndShdEff/(ResistanceLeafBoundary+ResistanceStomataShade))
        ExchCoeffLhUndCan = 1.0 / (ResistanceLhUndCan + ResistanceGrdEvap)

--- a/src/SurfaceEnergyFluxVegetatedMod.F90
+++ b/src/SurfaceEnergyFluxVegetatedMod.F90
@@ -272,7 +272,6 @@ contains
 
        ! latent heat conductance and coeff above veg.
        ExchCoeffLhAbvCan = 1.0 / ResistanceLhAbvCan
-       ExchCoeffLhEvap   = CanopyWetFrac * VegAreaIndTmp / ResistanceLeafBoundary
 
        HeatLatentPotCanEvap = VegFrac * DensityAirRefHeight * ConstHeatCapacAir * VegAreaIndTmp / ResistanceLeafBoundary * &
                               (VapPresSatCanopy - PressureVaporCanAir) / PsychConstCanopy


### PR DESCRIPTION
A fix for issue of vegetation temperature with wet canopy based on NOAA:
https://github.com/ufs-community/ccpp-physics/blob/9e709790d12301e697634e55af25224708b54a80/physics/SFC_Models/Land/Noahmp/module_sf_noahmplsm.F90#L4240-L4250

The bug may not produce the proper solution of vegetation temperature when canopy interception exists;
NOAA verions had the bug fixed and results shew that the modeling skills of 2-meter air temperature and dewpoint temperature was improved. 

in ccpp-physics/physics/module_sf_noahmplsm.f90
E = Ea (Tv) + Et(Tv) + Ec(Tv)			(1)
Ec(Tv)  <=  Cw  *  Lv/dt				(2)     
These two equations are used to solve the vegetation temperature Tv. Where E is the evaporation from canopy to atmosphere, Ea is the canopy air to atmosphere evaporation, Et is the canopy transpiration, Ec is the canopy evaporation, and Cw is the canopy interception. In the original code, in equation (1) Cw*Lv/dt is used to replace Ec(Tv) when Ec(Tv) is larger than Cw*Lv/dt, and then solve the equation. The resultant Tv can guarantee the energy conservation equation (1), but cannot guarantee the inequality (2). Thus, the equations have not been solved properly.



The test has been performed in WRF over CONUS at 4km