### PR TITLE
ERF Driver Print

### DIFF
--- a/drivers/erf/NoahmpReadLandMod.F90
+++ b/drivers/erf/NoahmpReadLandMod.F90
@@ -532,7 +532,6 @@ subroutine init_interp(xstart, xend, ystart, yend, nsoil, sldpth, var, nvar, src
        endif
        !if (rank == 0) print*, 'k, dst_centerpoint(k) = ', k, dst_centerpoint(k)
     enddo
-    print*
 
     do k = 1, nvar
        src_centerpoint(k) = 0.5*(layer_bottom(k)+layer_top(k))


### PR DESCRIPTION
# Summary
The print statement in `drivers/erf/NoahmpReadLandMod.F90` is not guarded with with an if IO rank and does not output meaningful information. This PR removes the superfluous print statement so it does not execute on every rank and blow out the log file for high rank count jobs.