### PR TITLE
pass STEPWTD from WRF to NoahMP coupling

### DIFF
--- a/drivers/wrf/NoahmpWRFinitMod.F90
+++ b/drivers/wrf/NoahmpWRFinitMod.F90
@@ -166,9 +166,9 @@ contains
     REAL,    DIMENSION(ims:ime,jms:jme),         INTENT(INOUT), OPTIONAL :: RIVERCONDXY  ! river conductance
     REAL,    DIMENSION(ims:ime,jms:jme),         INTENT(INOUT), OPTIONAL :: PEXPXY       ! factor for river conductance
     REAL,    DIMENSION(ims:ime,1:NSOIL,jms:jme), INTENT(INOUT), OPTIONAL :: smoiseq      ! equilibrium soil moisture content [m3m-3]
+    INTEGER,                                     INTENT(INOUT), OPTIONAL :: STEPWTD      ! step of MMF groundwater call 
     ! output only
     INTEGER, DIMENSION(ims:ime,jms:jme), INTENT(OUT)           :: cropcat             ! crop type
-    INTEGER,                             INTENT(OUT), OPTIONAL :: STEPWTD
     ! local
     integer :: itf, jtf, I, J
 ! ----------------------------------------------------------------------------------
@@ -352,6 +352,8 @@ contains
 
     enddo ! I
     enddo ! J
+
+    NoahmpIO%STEPWTD    = STEPWTD
 
     !--------- WRF -> NoahmpIO variables mapping ends
 


### PR DESCRIPTION
Address the issue that WRF crashed with restart file while using MMF groundwater scheme (runoff option = 5)

WRF restart was running fine after the fix, testing was done by Wei and Changhai   